### PR TITLE
Report git version with library_version

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -23,6 +23,10 @@ CXX			?= g++
 CC			?= gcc
 TARGET_NAME	= snes9x
 LIBM		= -lm
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(LAGFIX),1)
 CFLAGS   += -DLAGFIX

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DANDROID_ARM
 LOCAL_ARM_MODE := arm

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -254,7 +254,10 @@ void retro_get_system_info(struct retro_system_info *info)
     memset(info,0,sizeof(retro_system_info));
 
     info->library_name = "Snes9x";
-    info->library_version = VERSION;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+    info->library_version = VERSION GIT_VERSION;
     info->valid_extensions = "smc|sfc|swc|fig";
     info->need_fullpath = false;
     info->block_extract = false;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.