### PR TITLE
Fixing broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # snes9x libretro
 
-Issue Tracker: https://github.com/libretro/libretro-meta/labels/snes9x
+Issue Tracker: https://github.com/libretro/libretro-meta/labels/core:%20snes9x


### PR DESCRIPTION
Tag is "core: snes9x", not just "snes9x".