### PR TITLE
Silence some warnings

### DIFF
--- a/controls.cpp
+++ b/controls.cpp
@@ -2829,7 +2829,7 @@ void S9xSetJoypadLatch (bool latch)
 			switch (i = curcontrollers[n])
 			{
 				case MP5:
-					for (int j = 0, k = mp5[n].pads[j]; j < 4; k = mp5[n].pads[++j])
+					for (int j = 0, k = mp5[n].pads[j]; j < 3; k = mp5[n].pads[++j])
 					{
 						if (k == NONE)
 							continue;
@@ -3117,7 +3117,7 @@ void S9xControlEOF (void)
 		switch (i = curcontrollers[n])
 		{
 			case MP5:
-				for (j = 0, i = mp5[n].pads[j]; j < 4; i = mp5[n].pads[++j])
+				for (j = 0, i = mp5[n].pads[j]; j < 3; i = mp5[n].pads[++j])
 				{
 					if (i == NONE)
 						continue;


### PR DESCRIPTION
Silences the following warnings.
```
../controls.cpp: In function ‘void S9xSetJoypadLatch(bool)’:
../controls.cpp:2832:68: warning: iteration 3u invokes undefined behavior [-Waggressive-loop-optimizations]
      for (int j = 0, k = mp5[n].pads[j]; j < 4; k = mp5[n].pads[++j])
                                                                    ^
../controls.cpp:2832:44: note: containing loop
      for (int j = 0, k = mp5[n].pads[j]; j < 4; k = mp5[n].pads[++j])
                                            ^
../controls.cpp: In function ‘void S9xControlEOF()’:
../controls.cpp:3120:63: warning: iteration 3u invokes undefined behavior [-Waggressive-loop-optimizations]
     for (j = 0, i = mp5[n].pads[j]; j < 4; i = mp5[n].pads[++j])
                                                               ^
../controls.cpp:3120:39: note: containing loop
     for (j = 0, i = mp5[n].pads[j]; j < 4; i = mp5[n].pads[++j])
                                       ^
../controls.cpp:3120:63: warning: array subscript is above array bounds [-Warray-bounds]
     for (j = 0, i = mp5[n].pads[j]; j < 4; i = mp5[n].pads[++j])
                                                               ^
```
My understanding is that there are four `pads` and if `j = 0`, then it should be 3 not 4. If you count 0 you will get 4 `pads`. Please correct this if I didn't understand it correctly.
