### PR TITLE
Cheat support

### DIFF
--- a/cheats.cpp
+++ b/cheats.cpp
@@ -256,6 +256,9 @@ const char * S9xGoldFingerToRaw (const char *code, uint32 &address, bool8 &sram,
 	if (sscanf(tmp, "%x", &address) != 1)
 		return ("Invalid Gold Finger code.");
 
+	//Correct GoldFinger Address
+	address=(address&0x7FFF)|((address&0x7F8000)<<1)|0x8000;
+
 	for (i = 0; i < 3; i++)
 	{
 		unsigned int	byte;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -371,28 +371,36 @@ void retro_cheat_reset()
    S9xApplyCheats();
 }
 
-void retro_cheat_set(unsigned index, bool enabled, const char *code)
+void retro_cheat_set(unsigned index, bool enabled, const char *codeline)
 {
    uint32 address;
    uint8 val;
 
    bool8 sram;
    uint8 bytes[3];//used only by GoldFinger, ignored for now
+   char codeCopy[256];
+   char* code;
 
-   if (S9xGameGenieToRaw(code, address, val)!=NULL &&
-       S9xProActionReplayToRaw(code, address, val)!=NULL &&
-       S9xGoldFingerToRaw(code, address, sram, val, bytes)!=NULL)
-   { // bad code, ignore
-      return;
+   strcpy(codeCopy,codeline);
+   code=strtok(codeCopy,"+,.; ");
+   while (code != NULL) {
+      if (S9xGameGenieToRaw(code, address, val)!=NULL &&
+          S9xProActionReplayToRaw(code, address, val)!=NULL &&
+          S9xGoldFingerToRaw(code, address, sram, val, bytes)!=NULL)
+      { // bad code, ignore
+         return;
+      }
+      if (index>Cheat.num_cheats) return; // cheat added in weird order, ignore
+      if (index==Cheat.num_cheats) Cheat.num_cheats++;
+
+      Cheat.c[index].address = address;
+      Cheat.c[index].byte = val;
+      Cheat.c[index].enabled = enabled;
+
+      Cheat.c[index].saved = FALSE; // it'll be saved next time cheats run anyways
+
+      code=strtok(codeCopy,"+,.; ");
    }
-   if (index>Cheat.num_cheats) return; // cheat added in weird order, ignore
-   if (index==Cheat.num_cheats) Cheat.num_cheats++;
-
-   Cheat.c[index].address = address;
-   Cheat.c[index].byte = val;
-   Cheat.c[index].enabled = enabled;
-
-   Cheat.c[index].saved = FALSE; // it'll be saved next time cheats run anyways
 
    Settings.ApplyCheats=true;
    S9xApplyCheats();


### PR DESCRIPTION
Changelog

* Add support for multiline cheats.  Delimiters are "+,.; "
* Fix GoldFinger cheats.  Addresses are now properly decoded.  Values are accurately processed.  Multibyte cheats are supported.
* Add support for GameHacking.org RAW cheats.  