### PR TITLE
Fix -fpermissive build error

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -381,7 +381,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *codeline)
    char codeCopy[256];
    char* code;
 
-   if (codeline == '\0') return;
+   if (codeline == (char *)'\0') return;
 
    strcpy(codeCopy,codeline);
    code=strtok(codeCopy,"+,.; ");


### PR DESCRIPTION
Fixes the following build error with gcc-7.1.0.
```
../libretro/libretro.cpp:384:20: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
    if (codeline == '\0') return;
                    ^~~~
```
This was introduced in PR https://github.com/libretro/snes9x/pull/45.

After building snes9x successfully I tested cheats and they seem to work.

Also see https://github.com/libretro/bsnes-mercury/pull/48 and https://github.com/libretro/bsnes-libretro/pull/39 for related fixes.