### PR TITLE
Silence -Wimplicit-fallthrough warnings

### DIFF
--- a/dma.cpp
+++ b/dma.cpp
@@ -630,100 +630,88 @@ bool8 S9xDoDMA (uint8 Channel)
 				else
 				if (d->TransferMode == 3 || d->TransferMode == 7)
 				{
-					switch (b)
+					do
 					{
-						default:
-						do
+						Work = S9xGetByte((d->ABank << 16) + p);
+						if (b == 2 || b == 3)
 						{
-							Work = S9xGetByte((d->ABank << 16) + p);
-							S9xSetPPU(Work, 0x2100 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 1;
-								break;
-							}
-
-						case 1:
-							Work = S9xGetByte((d->ABank << 16) + p);
-							S9xSetPPU(Work, 0x2100 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 2;
-								break;
-							}
-
-						case 2:
-							Work = S9xGetByte((d->ABank << 16) + p);
 							S9xSetPPU(Work, 0x2101 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
+						}
+						else
+						{
+							S9xSetPPU(Work, 0x2100 + d->BAddress);
+						}
+						UPDATE_COUNTERS;
+						if (--count <= 0)
+						{
+							switch (b)
 							{
-								b = 3;
-								break;
-							}
+								default:
+									b = 1;
+									break;
 
-						case 3:
-							Work = S9xGetByte((d->ABank << 16) + p);
-							S9xSetPPU(Work, 0x2101 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 0;
-								break;
+								case 1:
+									b = 2;
+									break;
+
+								case 2:
+									b = 3;
+									break;
+
+								case 3:
+									b = 0;
+									break;
 							}
-						} while (1);
-					}
+						}
+					} while (1);
 				}
 				else
 				if (d->TransferMode == 4)
 				{
-					switch (b)
+					do
 					{
-						default:
-						do
+						Work = S9xGetByte((d->ABank << 16) + p);
+						if (b == 1)
 						{
-							Work = S9xGetByte((d->ABank << 16) + p);
-							S9xSetPPU(Work, 0x2100 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 1;
-								break;
-							}
-
-						case 1:
-							Work = S9xGetByte((d->ABank << 16) + p);
 							S9xSetPPU(Work, 0x2101 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 2;
-								break;
-							}
-
-						case 2:
-							Work = S9xGetByte((d->ABank << 16) + p);
+						}
+						else
+						if (b == 2)
+						{
 							S9xSetPPU(Work, 0x2102 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 3;
-								break;
-							}
-
-						case 3:
-							Work = S9xGetByte((d->ABank << 16) + p);
+						}
+						else
+						if (b == 3)
+						{
 							S9xSetPPU(Work, 0x2103 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
+						}
+						else
+						{
+							S9xSetPPU(Work, 0x2100 + d->BAddress);
+						}
+						UPDATE_COUNTERS;
+						if (--count <= 0)
+						{
+							switch (b)
 							{
-								b = 0;
-								break;
+								default:
+									b = 1;
+									break;
+
+								case 1:
+									b = 2;
+									break;
+
+								case 2:
+									b = 3;
+									break;
+
+								case 3:
+									b = 0;
+									break;
 							}
-						} while (1);
-					}
+						}
+					} while (1);
 				}
 			#ifdef DEBUGGER
 				else
@@ -937,100 +925,88 @@ bool8 S9xDoDMA (uint8 Channel)
 				else
 				if (d->TransferMode == 3 || d->TransferMode == 7)
 				{
-					switch (b)
+					do
 					{
-						default:
-						do
+						Work = *(base + p);
+						if (b == 2 || b == 3)
 						{
-							Work = *(base + p);
-							S9xSetPPU(Work, 0x2100 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 1;
-								break;
-							}
-
-						case 1:
-							Work = *(base + p);
-							S9xSetPPU(Work, 0x2100 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 2;
-								break;
-							}
-
-						case 2:
-							Work = *(base + p);
 							S9xSetPPU(Work, 0x2101 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
+						}
+						else
+						{
+							S9xSetPPU(Work, 0x2100 + d->BAddress);
+						}
+						UPDATE_COUNTERS;
+						if (--count <= 0)
+						{
+							switch (b)
 							{
-								b = 3;
-								break;
-							}
+								default:
+									b = 1;
+									break;
 
-						case 3:
-							Work = *(base + p);
-							S9xSetPPU(Work, 0x2101 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 0;
-								break;
+								case 1:
+									b = 2;
+									break;
+
+								case 2:
+									b = 3;
+									break;
+
+								case 3:
+									b = 0;
+									break;
 							}
-						} while (1);
-					}
+						}
+					} while (1);
 				}
 				else
 				if (d->TransferMode == 4)
 				{
-					switch (b)
+					do
 					{
-						default:
-						do
+						Work = *(base + p);
+						if (b == 1)
 						{
-							Work = *(base + p);
-							S9xSetPPU(Work, 0x2100 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 1;
-								break;
-							}
-
-						case 1:
-							Work = *(base + p);
 							S9xSetPPU(Work, 0x2101 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 2;
-								break;
-							}
-
-						case 2:
-							Work = *(base + p);
+						}
+						else
+						if (b == 2)
+						{
 							S9xSetPPU(Work, 0x2102 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
-							{
-								b = 3;
-								break;
-							}
-
-						case 3:
-							Work = *(base + p);
+						}
+						else
+						if (b == 3)
+						{
 							S9xSetPPU(Work, 0x2103 + d->BAddress);
-							UPDATE_COUNTERS;
-							if (--count <= 0)
+						}
+						else
+						{
+							S9xSetPPU(Work, 0x2100 + d->BAddress);
+						}
+						UPDATE_COUNTERS;
+						if (--count <= 0)
+						{
+							switch (b)
 							{
-								b = 0;
-								break;
+								default:
+									b = 1;
+									break;
+
+								case 1:
+									b = 2;
+									break;
+
+								case 2:
+									b = 3;
+									break;
+
+								case 3:
+									b = 0;
+									break;
 							}
-						} while (1);
-					}
+						}
+					} while (1);
 				}
 			#ifdef DEBUGGER
 				else


### PR DESCRIPTION
Silences the following `-Wimplicit-fallthrough=` warnings. Please review.
```
g++ -I../libretro -I.. -I../apu/ -I../apu/bapu  -DGIT_VERSION=\"" c32d4e3"\" -DLAGFIX -O3 -DNDEBUG -fno-exceptions -fomit-frame-pointer -fno-rtti -pedantic -Wall -W -Wno-unused-parameter -fPIC -DHAVE_STRINGS_H -DRIGHTSHIFT_IS_SAR -D__LIBRETRO__ -c -o ../dma.o ../dma.cpp
../dma.cpp:641:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:647:7: note: here
       case 1:
       ^~~~
../dma.cpp:651:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:657:7: note: here
       case 2:
       ^~~~
../dma.cpp:661:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:667:7: note: here
       case 3:
       ^~~~
../dma.cpp:690:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:696:7: note: here
       case 1:
       ^~~~
../dma.cpp:700:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:706:7: note: here
       case 2:
       ^~~~
../dma.cpp:710:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:716:7: note: here
       case 3:
       ^~~~
../dma.cpp:948:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:954:7: note: here
       case 1:
       ^~~~
../dma.cpp:958:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:964:7: note: here
       case 2:
       ^~~~
../dma.cpp:968:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:974:7: note: here
       case 3:
       ^~~~
../dma.cpp:997:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:1003:7: note: here
       case 1:
       ^~~~
../dma.cpp:1007:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:1013:7: note: here
       case 2:
       ^~~~
../dma.cpp:1017:8: warning: this statement may fall through [-Wimplicit-fallthrough=]
        if (--count <= 0)
        ^~
../dma.cpp:1023:7: note: here
       case 3:
       ^~~~
```