### PR TITLE
Fix build in VS

### DIFF
--- a/port.h
+++ b/port.h
@@ -253,7 +253,7 @@ typedef uint64_t			uint64;
 
 #if defined(__WIN32__)
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #define strcasecmp	stricmp
 #define strncasecmp	strnicmp


### PR DESCRIPTION
Looks like even the latest Visual Studio doesn't have `strcasecmp	` or `strnicmp`

This change allows project to build.