### PR TITLE
Updated version string from 1.53 to 1.54.1

### DIFF
--- a/snes9x.h
+++ b/snes9x.h
@@ -189,7 +189,7 @@
 #define _SNES9X_H_
 
 #ifndef VERSION
-#define VERSION	"1.53"
+#define VERSION	"1.54.1"
 #endif
 
 #include "port.h"


### PR DESCRIPTION
Qwertymodo's update to the original Snes9x 1.53 to enable MSU-1 bumped the version to 1.54.1.
https://github.com/snes9xgit/snes9x/blob/master/snes9x.h

The version might change soon to 1.55 according to the latest modifications made to the Snes9x Repository.