### PR TITLE
Aspect ratio is now updated if ScreenHeight changes outside S9xMainLoop()

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -969,16 +969,18 @@ static void report_buttons()
 
 void retro_run()
 {
-   uint16 height = PPU.ScreenHeight;
+   static uint16 height = PPU.ScreenHeight;
    bool updated = false;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       update_variables();
-
+   if (height != PPU.ScreenHeight)
+   {
+      update_geometry();
+      height = PPU.ScreenHeight;
+   }
    poll_cb();
    report_buttons();
    S9xMainLoop();
-   if (height != PPU.ScreenHeight)
-     update_geometry();
 }
 
 void retro_deinit()
@@ -1080,7 +1082,6 @@ bool retro_unserialize(const void* data, size_t size)
 {
    if (S9xUnfreezeGameMem((const uint8_t*)data,size) != SUCCESS)
       return false;
-   /* update_geometry();*/
    return true;
 }
 


### PR DESCRIPTION
Fixes the issue that the aspect ratio is wrong after deserialization if the PPU.ScreenHeight changes during the process, because screen geometry is not anymore updated explicitly after deserialization.

Originally described here: https://github.com/libretro/snes9x/pull/52