### PR TITLE
Silence -Wimplicit-fallthrough= warnings with comments instead

### DIFF
--- a/tile.cpp
+++ b/tile.cpp
@@ -840,7 +840,7 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 #define DRAW_TILE() \
 	uint8			*pCache; \
 	register int32	l; \
-	register uint8	*bp, Pix, w, n; \
+	register uint8	*bp, Pix, w; \
 	\
 	GET_CACHED_TILE(); \
 	if (IS_BLANK_TILE()) \
@@ -853,11 +853,17 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		for (l = LineCount; l > 0; l--, bp += 8 * PITCH, Offset += GFX.PPL) \
 		{ \
 			w = Width; \
-			n = StartPixel; \
-			do { \
-				DRAW_PIXEL(n, Pix = bp[n]); \
-				n++; \
-			} while (--w > 0); \
+			switch (StartPixel) \
+			{ \
+				case 0: DRAW_PIXEL(0, Pix = bp[0]); if (!--w) break; /* Fall through */ \
+				case 1: DRAW_PIXEL(1, Pix = bp[1]); if (!--w) break; /* Fall through */ \
+				case 2: DRAW_PIXEL(2, Pix = bp[2]); if (!--w) break; /* Fall through */ \
+				case 3: DRAW_PIXEL(3, Pix = bp[3]); if (!--w) break; /* Fall through */ \
+				case 4: DRAW_PIXEL(4, Pix = bp[4]); if (!--w) break; /* Fall through */ \
+				case 5: DRAW_PIXEL(5, Pix = bp[5]); if (!--w) break; /* Fall through */ \
+				case 6: DRAW_PIXEL(6, Pix = bp[6]); if (!--w) break; /* Fall through */ \
+				case 7: DRAW_PIXEL(7, Pix = bp[7]); break; \
+			} \
 		} \
 	} \
 	else \
@@ -867,11 +873,17 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		for (l = LineCount; l > 0; l--, bp += 8 * PITCH, Offset += GFX.PPL) \
 		{ \
 			w = Width; \
-			n = StartPixel; \
-			do { \
-				DRAW_PIXEL(n, Pix = bp[7 - n]); \
-				n++; \
-			} while (--w > 0); \
+			switch (StartPixel) \
+			{ \
+				case 0: DRAW_PIXEL(0, Pix = bp[7]); if (!--w) break; /* Fall through */ \
+				case 1: DRAW_PIXEL(1, Pix = bp[6]); if (!--w) break; /* Fall through */ \
+				case 2: DRAW_PIXEL(2, Pix = bp[5]); if (!--w) break; /* Fall through */ \
+				case 3: DRAW_PIXEL(3, Pix = bp[4]); if (!--w) break; /* Fall through */ \
+				case 4: DRAW_PIXEL(4, Pix = bp[3]); if (!--w) break; /* Fall through */ \
+				case 5: DRAW_PIXEL(5, Pix = bp[2]); if (!--w) break; /* Fall through */ \
+				case 6: DRAW_PIXEL(6, Pix = bp[1]); if (!--w) break; /* Fall through */ \
+				case 7: DRAW_PIXEL(7, Pix = bp[0]); break; \
+			} \
 		} \
 	} \
 	else \
@@ -881,11 +893,17 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		for (l = LineCount; l > 0; l--, bp -= 8 * PITCH, Offset += GFX.PPL) \
 		{ \
 			w = Width; \
-			n = StartPixel; \
-			do { \
-				DRAW_PIXEL(n, Pix = bp[n]); \
-				n++; \
-			} while (--w > 0); \
+			switch (StartPixel) \
+			{ \
+				case 0: DRAW_PIXEL(0, Pix = bp[0]); if (!--w) break; /* Fall through */ \
+				case 1: DRAW_PIXEL(1, Pix = bp[1]); if (!--w) break; /* Fall through */ \
+				case 2: DRAW_PIXEL(2, Pix = bp[2]); if (!--w) break; /* Fall through */ \
+				case 3: DRAW_PIXEL(3, Pix = bp[3]); if (!--w) break; /* Fall through */ \
+				case 4: DRAW_PIXEL(4, Pix = bp[4]); if (!--w) break; /* Fall through */ \
+				case 5: DRAW_PIXEL(5, Pix = bp[5]); if (!--w) break; /* Fall through */ \
+				case 6: DRAW_PIXEL(6, Pix = bp[6]); if (!--w) break; /* Fall through */ \
+				case 7: DRAW_PIXEL(7, Pix = bp[7]); break; \
+			} \
 		} \
 	} \
 	else \
@@ -894,11 +912,17 @@ void S9xSelectTileConverter (int depth, bool8 hires, bool8 sub, bool8 mosaic)
 		for (l = LineCount; l > 0; l--, bp -= 8 * PITCH, Offset += GFX.PPL) \
 		{ \
 			w = Width; \
-			n = StartPixel; \
-			do { \
-				DRAW_PIXEL(n, Pix = bp[7 - n]); \
-				n++; \
-			} while (--w > 0); \
+			switch (StartPixel) \
+			{ \
+				case 0: DRAW_PIXEL(0, Pix = bp[7]); if (!--w) break; /* Fall through */ \
+				case 1: DRAW_PIXEL(1, Pix = bp[6]); if (!--w) break; /* Fall through */ \
+				case 2: DRAW_PIXEL(2, Pix = bp[5]); if (!--w) break; /* Fall through */ \
+				case 3: DRAW_PIXEL(3, Pix = bp[4]); if (!--w) break; /* Fall through */ \
+				case 4: DRAW_PIXEL(4, Pix = bp[3]); if (!--w) break; /* Fall through */ \
+				case 5: DRAW_PIXEL(5, Pix = bp[2]); if (!--w) break; /* Fall through */ \
+				case 6: DRAW_PIXEL(6, Pix = bp[1]); if (!--w) break; /* Fall through */ \
+				case 7: DRAW_PIXEL(7, Pix = bp[0]); break; \
+			} \
 		} \
 	}
 


### PR DESCRIPTION
Upstream snes9x fixed these extremely spammy warnings differently which according to them is faster. The fps in RetroArch suggest that it might be a little faster.

Mostly this just removes one more difference between upstream and the libretro core.

Also see:
https://github.com/libretro/snes9x/pull/48
https://github.com/snes9xgit/snes9x/pull/200
https://github.com/snes9xgit/snes9x/commit/d441856303cfbcd19ca9c2cd73bdc8a8f412394a