### PR TITLE
Add 20MHz Super FX Overclock Option

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -122,7 +122,7 @@ void retro_set_environment(retro_environment_t cb)
       // These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
       // Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
       // Adding more variables and rearranging them is safe.
-      { "snes9x_overclock", "SuperFX Overclock; disabled|40MHz|60MHz|80MHz|100MHz" },
+      { "snes9x_overclock", "SuperFX Overclock; disabled|20MHz|40MHz|60MHz|80MHz|100MHz" },
       { "snes9x_layer_1", "Show layer 1; enabled|disabled" },
       { "snes9x_layer_2", "Show layer 2; enabled|disabled" },
       { "snes9x_layer_3", "Show layer 3; enabled|disabled" },
@@ -191,6 +191,11 @@ static void update_variables(void)
       if (strcmp(var.value, "disabled") == 0)
       {
          Settings.SuperFXSpeedPerLine = 0.417 * 10.5e6;
+         reset_sfx = true;
+      }
+      else if (strcmp(var.value, "20MHz") == 0)
+      {
+         Settings.SuperFXSpeedPerLine = 0.417 * 20.5e6;
          reset_sfx = true;
       }
       else if (strcmp(var.value, "40MHz") == 0)


### PR DESCRIPTION
Most SNES emulators currently have options to overclock the Super FX chip to 40MHz, 60MHz, 80MHz, and 100MHz. This makes many games (Star Fox is the common example) smoother, but play much faster than intended.
I don't understand why there isn't a 20MHz overclock option for games that use the original GSU-1 (or MARIO CHIP 1) that could benefit from it. I propose a 20MHz setting to allow these games to receive a reasonable, playable speedup.
This linked video ( https://www.youtube.com/watch?v=3gVg8vDhfQk ) demonstrates the output of libretro-snes9x with snes9x_overclock set to "disabled", "20MHz" (new), and "40MHz", simultaneously.