### PR TITLE
Fix device mouse not working in player port #2

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -375,7 +375,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
             snes_devices[port] = RETRO_DEVICE_JOYPAD_MULTITAP;
             break;
          case RETRO_DEVICE_MOUSE:
-            S9xSetController(port, CTL_MOUSE, 0, 0, 0, 0);
+            S9xSetController(port, CTL_MOUSE, port, 0, 0, 0);
             snes_devices[port] = RETRO_DEVICE_MOUSE;
             break;
          case RETRO_DEVICE_LIGHTGUN_SUPER_SCOPE:


### PR DESCRIPTION
Some mouse-compatible games can work with gamepad on port 1 and mouse on port 2, but when setting mouse device on port 2, it does not work.

Similar issue:
https://github.com/libretro/snes9x2010/issues/94