### PR TITLE
Backport SA1 Speed Fix

### DIFF
--- a/sa1cpu.cpp
+++ b/sa1cpu.cpp
@@ -307,7 +307,7 @@ void S9xSA1MainLoop (void)
 		}
 	}
 
-	for (int i = 0; i < 3 && !(Memory.FillRAM[0x2200] & 0x60); i++)
+	for (int i = 0; i < 5 && !(Memory.FillRAM[0x2200] & 0x60); i++)
 	{
 	#ifdef DEBUGGER
 		if (SA1.Flags & TRACE_FLAG)


### PR DESCRIPTION
https://github.com/snes9xgit/snes9x/commit/162ccbb1530c826182eb16f0bdbfa463225aca0c

Fixes slowdown in Kirby Super Star's intro, as discussed here: https://github.com/snes9xgit/snes9x/issues/71#issuecomment-346202861