### PR TITLE
snes9x core for Solaris

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -52,7 +52,12 @@ endif
 ifneq (,$(findstring unix,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
+   ifneq ($(findstring SunOS,$(shell uname -a)),)
+   CC = gcc
+   SHARED := -shared -z defs
+   else
    SHARED := -shared -Wl,--version-script=link.T
+   endif
    ifneq ($(findstring Haiku,$(shell uname -a)),)
       LIBS :=
    endif


### PR DESCRIPTION
This allows the snes9x core to build on Solaris 11