### PR TITLE
Overclock by reducing cycles. (for testing)

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -43,6 +43,7 @@
 
 char g_rom_dir[1024];
 char g_basename[1024];
+bool overclock_cycles = false;
 
 retro_log_printf_t log_cb = NULL;
 static retro_video_refresh_t video_cb = NULL;
@@ -123,6 +124,7 @@ void retro_set_environment(retro_environment_t cb)
       // Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
       // Adding more variables and rearranging them is safe.
       { "snes9x_overclock", "SuperFX Frequency; 10MHz|20MHz|40MHz|60MHz|80MHz|100MHz" },
+      { "snes9x_overclock_cycles", "CPU Overclock (Hack, Unsafe); disabled|enabled" },
       { "snes9x_layer_1", "Show layer 1; enabled|disabled" },
       { "snes9x_layer_2", "Show layer 2; enabled|disabled" },
       { "snes9x_layer_3", "Show layer 3; enabled|disabled" },
@@ -194,6 +196,16 @@ static void update_variables(void)
       reset_sfx = true;
    }
 
+   var.key = "snes9x_overclock_cycles";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      {
+        if (strcmp(var.value, "enabled") == 0)
+          overclock_cycles = true;
+        else
+          overclock_cycles = false;
+      }
 
    int disabled_channels=0;
    strcpy(key, "snes9x_sndchan_x");

--- a/snes9x.h
+++ b/snes9x.h
@@ -249,9 +249,9 @@
 #define SNES_MAX_PAL_VCOUNTER		312
 #define SNES_HCOUNTER_MAX			341
 
-#define ONE_CYCLE					6
-#define SLOW_ONE_CYCLE				8
-#define TWO_CYCLES					12
+#define ONE_CYCLE						(overclock_cycles ? 4 : 6)
+#define SLOW_ONE_CYCLE				(overclock_cycles ? 4 : 8)
+#define TWO_CYCLES					(overclock_cycles ? 6 : 12)
 #define	ONE_DOT_CYCLE				4
 
 #define SNES_CYCLES_PER_SCANLINE	(SNES_HCOUNTER_MAX * ONE_DOT_CYCLE)
@@ -290,6 +290,8 @@
 
 #define ROM_NAME_LEN	23
 #define AUTO_FRAMERATE	200
+
+extern bool overclock_cycles;
 
 struct SCPUState
 {


### PR DESCRIPTION
I was trying to get rid of the usual SNES slow downs by changing some values and got interested results with that change here.
It's a lot better in games I tested: Super R-Type, Gradius 3, Super Ghouls'n Ghosts...
I was surprised Super FX games seem to work fine too (haven't done a lot of tests yet though).

**I've got no idea if what I'm doing is safe, it's here for experiment/feedback.**

Found bug: small visual glitch with the ocean wave in SG'N'G first stage.
