### PR TITLE
Fix missing audio samples after saving and loading state

### DIFF
--- a/apu/apu.cpp
+++ b/apu/apu.cpp
@@ -738,6 +738,25 @@ void S9xAPUSaveState (uint8 *block)
 	ptr += sizeof(int32);
 	memcpy (ptr, SNES::cpu.registers, 4);
 	ptr += sizeof(int32);
+	
+	//sample count within buffer
+	int sampleCount = SNES::dsp.spc_dsp.sample_count();
+	SNES::set_le32(ptr, sampleCount);
+	ptr += sizeof(int32);
+	//samples remaining in landing buffer
+	int maxSize = SPC_SAVE_STATE_BLOCK_SIZE - (ptr - block);
+	int copySize = sampleCount * sizeof(SNES::SPC_DSP::sample_t);
+	if (copySize > maxSize) copySize = maxSize;
+
+	if (SNES::dsp.spc_dsp.GetOutputBufferBase() != NULL)
+	{
+		memcpy(ptr, SNES::dsp.spc_dsp.GetOutputBufferBase(), copySize);
+	}
+	else
+	{
+		memset(ptr, 0, copySize);
+	}
+	ptr += copySize;
 
 	memset (ptr, 0, SPC_SAVE_STATE_BLOCK_SIZE-(ptr-block));
 }
@@ -756,6 +775,19 @@ void S9xAPULoadState (uint8 *block)
 	SNES::dsp.clock = SNES::get_le32(ptr);
 	ptr += sizeof(int32);
 	memcpy (SNES::cpu.registers, ptr, 4);
+	ptr += 4;
+
+	//sample count within buffer
+	int sampleCount = SNES::get_le32(ptr);
+	if (sampleCount > 160) sampleCount = 160;
+	if (sampleCount < 0) sampleCount = 0;
+	ptr += sizeof(int32);
+
+	//samples for landing buffer
+	if (sampleCount > 0)
+	{
+		SNES::dsp.spc_dsp.EnqueueSamples((const SNES::SPC_DSP::sample_t*)ptr, sampleCount);
+	}
 }
 
 static void to_var_from_buf (uint8 **buf, void *var, size_t size)

--- a/apu/bapu/dsp/SPC_DSP.cpp
+++ b/apu/bapu/dsp/SPC_DSP.cpp
@@ -1061,3 +1061,14 @@ int SPC_DSP::envx_value( int ch )
 {
 	return m.voices[ch].env;
 }
+
+bool SPC_DSP::EnqueueSamples(const sample_t *samples, int sampleCount)
+{
+	//used to restore samples back to the output buffer when loading state
+	if (m.out_begin == NULL) return false;
+	int samplesRemaining = m.out_end - m.out;
+	if (sampleCount > samplesRemaining) return false;
+	memcpy(m.out, samples, sampleCount * sizeof(sample_t));
+	m.out += sampleCount;
+	return true;
+}

--- a/apu/bapu/dsp/SPC_DSP.h
+++ b/apu/bapu/dsp/SPC_DSP.h
@@ -244,6 +244,15 @@ private:
 	void echo_30();
 
 	void soft_reset_common();
+
+public:
+	//Used to read samples from the output buffer when saving state.
+	const sample_t *GetOutputBufferBase()
+	{
+		return m.out_begin;
+	}
+	//Used to place samples in the output buffer when loading state
+	bool EnqueueSamples(const sample_t *samples, int sampleCount);
 };
 
 #include <assert.h>

--- a/apu/hermite_resampler.h
+++ b/apu/hermite_resampler.h
@@ -66,6 +66,13 @@ class HermiteResampler : public Resampler
         void
         read (short *data, int num_samples)
         {
+			//If we are outputting the exact same ratio as the input, pull directly from the input buffer
+			if (r_step == 1.0)
+			{
+				ring_buffer::pull((unsigned char*)data, num_samples * sizeof(short));
+				return;
+			}
+
             int i_position = start >> 1;
             int max_samples = buffer_size >> 1;
             short *internal_buffer = (short *) buffer;
@@ -120,7 +127,13 @@ class HermiteResampler : public Resampler
         inline int
         avail (void)
         {
-            return (int) floor (((size >> 2) - r_frac) / r_step) * 2;
+			//If we are outputting the exact same ratio as the input, find out directly from the input buffer
+			if (r_step == 1.0)
+			{
+				return (ring_buffer::space_filled() + sizeof(short) - 1) / sizeof(short);
+			}
+
+			return (int) floor (((size >> 2) - r_frac) / r_step) * 2;
         }
 };
 


### PR DESCRIPTION
Changes made:

- Save state file format slightly changed, now includes the count of samples in the output buffer, and includes the contents of the output buffer.  This is usually very tiny, I was getting 28 samples in there, but it could possibly be as big as 132 samples.  If it reads an old save state, it will be zeroes, so the number of samples it will try to read is zero.
- Changes made to SNES_DSP to allow directly stuffing samples into the output buffer, needed for loading state.
- Hermite Resampler changed to bypass the resampler completely if there is no resampling to do, as in RetroArch.
- Drastically shrunk the buffer sizes in RetroArch.cpp, sizes above 256 samples were not needed.
