### PR TITLE
Eliminate sound buffer from savestates, and flush buffer in retro_run

### DIFF
--- a/apu/apu.cpp
+++ b/apu/apu.cpp
@@ -738,25 +738,6 @@ void S9xAPUSaveState (uint8 *block)
 	ptr += sizeof(int32);
 	memcpy (ptr, SNES::cpu.registers, 4);
 	ptr += sizeof(int32);
-	
-	//sample count within buffer
-	int sampleCount = SNES::dsp.spc_dsp.sample_count();
-	SNES::set_le32(ptr, sampleCount);
-	ptr += sizeof(int32);
-	//samples remaining in landing buffer
-	int maxSize = SPC_SAVE_STATE_BLOCK_SIZE - (ptr - block);
-	int copySize = sampleCount * sizeof(SNES::SPC_DSP::sample_t);
-	if (copySize > maxSize) copySize = maxSize;
-
-	if (SNES::dsp.spc_dsp.GetOutputBufferBase() != NULL)
-	{
-		memcpy(ptr, SNES::dsp.spc_dsp.GetOutputBufferBase(), copySize);
-	}
-	else
-	{
-		memset(ptr, 0, copySize);
-	}
-	ptr += copySize;
 
 	memset (ptr, 0, SPC_SAVE_STATE_BLOCK_SIZE-(ptr-block));
 }
@@ -776,18 +757,6 @@ void S9xAPULoadState (uint8 *block)
 	ptr += sizeof(int32);
 	memcpy (SNES::cpu.registers, ptr, 4);
 	ptr += 4;
-
-	//sample count within buffer
-	int sampleCount = SNES::get_le32(ptr);
-	if (sampleCount > 160) sampleCount = 160;
-	if (sampleCount < 0) sampleCount = 0;
-	ptr += sizeof(int32);
-
-	//samples for landing buffer
-	if (sampleCount > 0)
-	{
-		SNES::dsp.spc_dsp.EnqueueSamples((const SNES::SPC_DSP::sample_t*)ptr, sampleCount);
-	}
 }
 
 static void to_var_from_buf (uint8 **buf, void *var, size_t size)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1028,6 +1028,7 @@ void retro_run()
    poll_cb();
    report_buttons();
    S9xMainLoop();
+   S9xAudioCallback(NULL);
 }
 
 void retro_deinit()


### PR DESCRIPTION
After checking out the sound code, I decided to revert the change where it stores the sound buffer in the savestate.  Instead, I call S9xAudioCallback at the bottom of retro_run, this forces the sound buffer to be empty.  Thus there is no longer a need to keep the sound buffer in the savestate.