### PR TITLE
11% performance boost on x64 by reducing branches

### DIFF
--- a/cpuexec.h
+++ b/cpuexec.h
@@ -282,25 +282,25 @@ static inline void S9xFixCycles (void)
 
 static inline void S9xCheckInterrupts (void)
 {
-	bool8	thisIRQ = PPU.HTimerEnabled || PPU.VTimerEnabled;
+	bool8	thisIRQ = PPU.HTimerEnabled | PPU.VTimerEnabled;
 
-	if (CPU.IRQLine && thisIRQ)
+	if (CPU.IRQLine & thisIRQ)
 		CPU.IRQTransition = TRUE;
 
 	if (PPU.HTimerEnabled)
 	{
 		int32	htimepos = PPU.HTimerPosition;
-		if (CPU.Cycles >= Timings.H_Max && htimepos < CPU.PrevCycles)
+		if (CPU.Cycles >= Timings.H_Max & htimepos < CPU.PrevCycles)
 			htimepos += Timings.H_Max;
 
-		if (CPU.PrevCycles >= htimepos || CPU.Cycles < htimepos)
+		if (CPU.PrevCycles >= htimepos | CPU.Cycles < htimepos)
 			thisIRQ = FALSE;
 	}
 
 	if (PPU.VTimerEnabled)
 	{
 		int32	vcounter = CPU.V_Counter;
-        if (CPU.Cycles >= Timings.H_Max && (!PPU.HTimerEnabled || PPU.HTimerPosition < CPU.PrevCycles)) {
+        if (CPU.Cycles >= Timings.H_Max & (!PPU.HTimerEnabled | PPU.HTimerPosition < CPU.PrevCycles)) {
 			vcounter++;
             if(vcounter >= Timings.V_Max)
                 vcounter = 0;
@@ -310,7 +310,7 @@ static inline void S9xCheckInterrupts (void)
 			thisIRQ = FALSE;
 	}
 
-	if (!CPU.IRQLastState && thisIRQ)
+	if (!CPU.IRQLastState & thisIRQ)
 	{
 #ifdef DEBUGGER
 		S9xTraceFormattedMessage("--- /IRQ High->Low  prev HC:%04d  curr HC:%04d  HTimer:%d Pos:%04d  VTimer:%d Pos:%03d",


### PR DESCRIPTION
This may be architecture-specific, but on X64, if you replaced the logical boolean operators with arithmetic boolean operators, the compiler generates code with far fewer branches, and uses the CMOV instruction (conditional move) in more places.

In my testing, it ran 11% faster after making this change.

Haven't yet tested this change on other processors, like 32-bit x86, or ARM.