### PR TITLE
Video disabling, fast savestates, and hard audio disable

### DIFF
--- a/apu/bapu/dsp/SPC_DSP.cpp
+++ b/apu/bapu/dsp/SPC_DSP.cpp
@@ -1,5 +1,8 @@
 // snes_spc 0.9.0. http://www.slack.net/~ant/
 
+//include for the Settings struct
+#include "snes9x.h"
+
 #include "SPC_DSP.h"
 
 #include "blargg_endian.h"
@@ -795,6 +798,10 @@ PHASE(31)  V(V4,0)       V(V1,2)\
 
 void SPC_DSP::run( int clocks_remain )
 {
+	if (::Settings.HardDisableAudio)
+	{
+		return;
+	}
 	require( clocks_remain > 0 );
 
 	int const phase = m.phase;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1025,6 +1025,16 @@ void retro_run()
       update_geometry();
       height = PPU.ScreenHeight;
    }
+
+   int result = -1;
+   bool okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
+   if (!okay) result |= 3;
+   bool audioEnabled = 0 != (result & 2);
+   bool videoEnabled = 0 != (result & 1);
+
+   IPPU.RenderThisFrame = videoEnabled;
+   S9xSetSoundMute(!audioEnabled);
+
    poll_cb();
    report_buttons();
    S9xMainLoop();

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1030,18 +1030,18 @@ void retro_run()
    bool okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
    if (okay)
    {
-	   bool audioEnabled = 0 != (result & 2);
-	   bool videoEnabled = 0 != (result & 1);
-	   bool hardDisableAudio = 0 != (result & 8);
-	   IPPU.RenderThisFrame = videoEnabled;
-	   S9xSetSoundMute(!audioEnabled || hardDisableAudio);
-	   Settings.HardDisableAudio = hardDisableAudio;
+      bool audioEnabled = 0 != (result & 2);
+      bool videoEnabled = 0 != (result & 1);
+      bool hardDisableAudio = 0 != (result & 8);
+      IPPU.RenderThisFrame = videoEnabled;
+      S9xSetSoundMute(!audioEnabled || hardDisableAudio);
+      Settings.HardDisableAudio = hardDisableAudio;
    }
    else
    {
-	   IPPU.RenderThisFrame = true;;
-	   S9xSetSoundMute(false);
-	   Settings.HardDisableAudio = false;
+      IPPU.RenderThisFrame = true;
+      S9xSetSoundMute(false);
+      Settings.HardDisableAudio = false;
    }
 
    poll_cb();

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1028,12 +1028,21 @@ void retro_run()
 
    int result = -1;
    bool okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
-   if (!okay) result |= 3;
-   bool audioEnabled = 0 != (result & 2);
-   bool videoEnabled = 0 != (result & 1);
-
-   IPPU.RenderThisFrame = videoEnabled;
-   S9xSetSoundMute(!audioEnabled);
+   if (okay)
+   {
+	   bool audioEnabled = 0 != (result & 2);
+	   bool videoEnabled = 0 != (result & 1);
+	   bool hardDisableAudio = 0 != (result & 8);
+	   IPPU.RenderThisFrame = videoEnabled;
+	   S9xSetSoundMute(!audioEnabled || hardDisableAudio);
+	   Settings.HardDisableAudio = hardDisableAudio;
+   }
+   else
+   {
+	   IPPU.RenderThisFrame = true;;
+	   S9xSetSoundMute(false);
+	   Settings.HardDisableAudio = false;
+   }
 
    poll_cb();
    report_buttons();
@@ -1130,7 +1139,14 @@ size_t retro_serialize_size()
 
 bool retro_serialize(void *data, size_t size)
 {
-   if (S9xFreezeGameMem((uint8_t*)data,size) == FALSE)
+	int result = -1;
+	bool okay = false;
+	okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
+	if (okay)
+	{
+		Settings.FastSavestates = 0 != (result & 4);
+	}
+	if (S9xFreezeGameMem((uint8_t*)data,size) == FALSE)
       return false;
 
    return true;
@@ -1138,8 +1154,16 @@ bool retro_serialize(void *data, size_t size)
 
 bool retro_unserialize(const void* data, size_t size)
 {
+   int result = -1;
+   bool okay = false;
+   okay = environ_cb(RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE, &result);
+   if (okay)
+   {
+	   Settings.FastSavestates = 0 != (result & 4);
+   }
    if (S9xUnfreezeGameMem((const uint8_t*)data,size) != SUCCESS)
       return false;
+
    return true;
 }
 

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -967,6 +967,8 @@ enum retro_mod
                                             * core supports VFS before it starts handing out paths.
                                             * It is recomended to do so in retro_set_environment */
 
+#define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+
 /* VFS functionality */
 
 /* File paths:

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -968,6 +968,46 @@ enum retro_mod
                                             * It is recomended to do so in retro_set_environment */
 
 #define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+											/* int * --
+											* Tells the core if the frontend wants audio or video.
+											* If disabled, the frontend will discard the audio or video,
+											* so the core may decide to skip generating a frame or generating audio.
+											* This is mainly used for increasing performance.
+											* Bit 0 (value 1): Enable Video
+											* Bit 1 (value 2): Enable Audio
+											* Bit 2 (value 4): Use Fast Savestates.
+											* Bit 3 (value 8): Hard Disable Audio
+											* Other bits are reserved for future use and will default to zero.
+											* If video is disabled:
+											* * The frontend wants the core to not generate any video,
+											*   including presenting frames via hardware acceleration.
+											* * The frontend's video frame callback will do nothing.
+											* * After running the frame, the video output of the next frame should be
+											*   no different than if video was enabled, and saving and loading state
+											*   should have no issues.
+											* If audio is disabled:
+											* * The frontend wants the core to not generate any audio.
+											* * The frontend's audio callbacks will do nothing.
+											* * After running the frame, the audio output of the next frame should be
+											*   no different than if audio was enabled, and saving and loading state
+											*   should have no issues.
+											* Fast Savestates:
+											* * Guaranteed to be created by the same binary that will load them.
+											* * Will not be written to or read from the disk.
+											* * Suggest that the core assumes loading state will succeed.
+											* * Suggest that the core updates its memory buffers in-place if possible.
+											* * Suggest that the core skips clearing memory.
+											* * Suggest that the core skips resetting the system.
+											* * Suggest that the core may skip validation steps.
+											* Hard Disable Audio:
+											* * Used for a secondary core when running ahead.
+											* * Indicates that the frontend will never need audio from the core.
+											* * Suggests that the core may stop synthesizing audio, but this should not
+											*   compromise emulation accuracy.
+											* * Audio output for the next frame does not matter, and the frontend will
+											*   never need an accurate audio state in the future.
+											* * State will never be saved when using Hard Disable Audio.
+											*/
 
 /* VFS functionality */
 

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -1813,6 +1813,21 @@ void S9xResetPPU (void)
 	PPU.M7byte = 0;
 }
 
+void S9xResetPPUFast (void)
+{
+	PPU.RecomputeClipWindows = TRUE;
+	IPPU.ColorsChanged = TRUE;
+	IPPU.OBJChanged = TRUE;
+	IPPU.DirectColourMapsNeedRebuild = TRUE;
+	memset(IPPU.TileCached[TILE_2BIT], 0, MAX_2BIT_TILES);
+	memset(IPPU.TileCached[TILE_4BIT], 0, MAX_4BIT_TILES);
+	memset(IPPU.TileCached[TILE_8BIT], 0, MAX_8BIT_TILES);
+	memset(IPPU.TileCached[TILE_2BIT_EVEN], 0, MAX_2BIT_TILES);
+	memset(IPPU.TileCached[TILE_2BIT_ODD], 0, MAX_2BIT_TILES);
+	memset(IPPU.TileCached[TILE_4BIT_EVEN], 0, MAX_4BIT_TILES);
+	memset(IPPU.TileCached[TILE_4BIT_ODD], 0, MAX_4BIT_TILES);
+}
+
 void S9xSoftResetPPU (void)
 {
 	S9xControlsSoftReset();

--- a/ppu.h
+++ b/ppu.h
@@ -380,6 +380,7 @@ extern struct SPPU			PPU;
 extern struct InternalPPU	IPPU;
 
 void S9xResetPPU (void);
+void S9xResetPPUFast (void);
 void S9xSoftResetPPU (void);
 void S9xSetPPU (uint8, uint16);
 uint8 S9xGetPPU (uint16);

--- a/snapshot.cpp
+++ b/snapshot.cpp
@@ -188,7 +188,6 @@
  ***********************************************************************************/
 
 #define SAVE_SCREENSHOT 0
-#define FAST_SAVESTATES 0
 
 #include <assert.h>
 #include "snes9x.h"
@@ -1410,7 +1409,7 @@ void S9xFreezeToStream (STREAM stream)
 
 int S9xUnfreezeFromStream (STREAM stream)
 {
-	const bool8 fast = FAST_SAVESTATES;
+	const bool8 fast = Settings.FastSavestates;
 
 	int		result = SUCCESS;
 	int		version, len;
@@ -2130,10 +2129,10 @@ static int UnfreezeBlock (STREAM stream, const char *name, uint8 *block, int siz
 		len = size;
 	}
 
-	#if FAST_SAVESTATES
-	#else
-	memset(block, 0, size);
-	#endif
+	if (!Settings.FastSavestates)
+	{
+		memset(block, 0, size);
+	}
 
 	if (READ_STREAM(block, len, stream) != len)
 	{

--- a/snapshot.cpp
+++ b/snapshot.cpp
@@ -187,6 +187,8 @@
   Nintendo Co., Limited and its subsidiary companies.
  ***********************************************************************************/
 
+#define SAVE_SCREENSHOT 0
+#define FAST_SAVESTATES 0
 
 #include <assert.h>
 #include "snes9x.h"
@@ -1152,6 +1154,8 @@ static FreezeData	SnapMSU1[] =
 };
 
 #undef STRUCT
+
+#if SAVE_SCREENSHOT
 #define STRUCT	struct SnapshotScreenshotInfo
 
 static FreezeData	SnapScreenshot[] =
@@ -1163,6 +1167,8 @@ static FreezeData	SnapScreenshot[] =
 };
 
 #undef STRUCT
+#endif
+
 #define STRUCT	struct SnapshotMovieInfo
 
 static FreezeData	SnapMovie[] =
@@ -1177,6 +1183,8 @@ static int UnfreezeStructCopy (STREAM, const char *, uint8 **, FreezeData *, int
 static void UnfreezeStructFromCopy (void *, FreezeData *, int, uint8 *, int);
 static void FreezeBlock (STREAM, const char *, uint8 *, int);
 static void FreezeStruct (STREAM, const char *, void *, FreezeData *, int);
+static bool CheckBlockName(STREAM stream, const char *name, int &len);
+static void SkipBlockWithName(STREAM stream, const char *name);
 
 
 void S9xResetSaveTimer (bool8 dontsave)
@@ -1402,6 +1410,8 @@ void S9xFreezeToStream (STREAM stream)
 
 int S9xUnfreezeFromStream (STREAM stream)
 {
+	const bool8 fast = FAST_SAVESTATES;
+
 	int		result = SUCCESS;
 	int		version, len;
 	char	buffer[PATH_MAX + 1];
@@ -1468,19 +1478,31 @@ int S9xUnfreezeFromStream (STREAM stream)
 		if (result != SUCCESS)
 			break;
 
-		result = UnfreezeBlockCopy (stream, "VRA", &local_vram, 0x10000);
+		if (fast)
+			result = UnfreezeBlock(stream, "VRA", Memory.VRAM, 0x10000);
+		else
+			result = UnfreezeBlockCopy(stream, "VRA", &local_vram, 0x10000);
 		if (result != SUCCESS)
 			break;
 
-		result = UnfreezeBlockCopy (stream, "RAM", &local_ram, 0x20000);
+		if (fast)
+			result = UnfreezeBlock(stream, "RAM", Memory.RAM, 0x20000);
+		else
+			result = UnfreezeBlockCopy(stream, "RAM", &local_ram, 0x20000);
 		if (result != SUCCESS)
 			break;
 
-		result = UnfreezeBlockCopy (stream, "SRA", &local_sram, 0x20000);
+		if (fast)
+			result = UnfreezeBlock(stream, "SRA", Memory.SRAM, 0x20000);
+		else
+			result = UnfreezeBlockCopy (stream, "SRA", &local_sram, 0x20000);
 		if (result != SUCCESS)
 			break;
 
-		result = UnfreezeBlockCopy (stream, "FIL", &local_fillram, 0x8000);
+		if (fast)
+			result = UnfreezeBlock(stream, "FIL", Memory.FillRAM, 0x8000);
+		else
+			result = UnfreezeBlockCopy(stream, "FIL", &local_fillram, 0x8000);
 		if (result != SUCCESS)
 			break;
 
@@ -1520,9 +1542,19 @@ int S9xUnfreezeFromStream (STREAM stream)
 		if (result != SUCCESS && Settings.DSP == 4)
 			break;
 
-		result = UnfreezeBlockCopy (stream, "CX4", &local_cx4_data, 8192);
-		if (result != SUCCESS && Settings.C4)
-			break;
+		if (Settings.C4)
+		{
+			if (fast)
+				result = UnfreezeBlock(stream, "CX4", Memory.C4RAM, 8192);
+			else
+				result = UnfreezeBlockCopy(stream, "CX4", &local_cx4_data, 8192);
+			if (result != SUCCESS)
+				break;
+		}
+		else
+		{
+			SkipBlockWithName(stream, "CX4");
+		}
 
 		result = UnfreezeStructCopy(stream, "ST0", &local_st010, SnapST010, COUNT(SnapST010), version);
 		if (result != SUCCESS && Settings.SETA == ST_010)
@@ -1532,9 +1564,19 @@ int S9xUnfreezeFromStream (STREAM stream)
 		if (result != SUCCESS && Settings.OBC1)
 			break;
 
-		result = UnfreezeBlockCopy (stream, "OBM", &local_obc1_data, 8192);
-		if (result != SUCCESS && Settings.OBC1)
-			break;
+		if (Settings.OBC1)
+		{
+			if (fast)
+				result = UnfreezeBlock(stream, "OBM", Memory.OBC1RAM, 8192);
+			else
+				result = UnfreezeBlockCopy(stream, "OBM", &local_obc1_data, 8192);
+			if (result != SUCCESS)
+				break;
+		}
+		else
+		{
+			SkipBlockWithName(stream, "OBM");
+		}
 
 		result = UnfreezeStructCopy(stream, "S71", &local_spc7110, SnapSPC7110Snap, COUNT(SnapSPC7110Snap), version);
 		if (result != SUCCESS && Settings.SPC7110)
@@ -1556,7 +1598,11 @@ int S9xUnfreezeFromStream (STREAM stream)
 		if (result != SUCCESS && Settings.MSU1)
 			break;
 
+#if SAVE_SCREENSHOT
 		result = UnfreezeStructCopy(stream, "SHO", &local_screenshot, SnapScreenshot, COUNT(SnapScreenshot), version);
+#else
+		SkipBlockWithName(stream, "SHO");
+#endif
 
 		SnapshotMovieInfo	mi;
 
@@ -1572,7 +1618,15 @@ int S9xUnfreezeFromStream (STREAM stream)
 		uint32 old_flags     = CPU.Flags;
 		uint32 sa1_old_flags = SA1.Flags;
 
-		S9xReset();
+		if (fast)
+		{
+			S9xResetPPUFast();
+		}
+		else
+		{
+			//Do not call this if you have written directly to "Memory." arrays
+			S9xReset();
+		}
 
 		UnfreezeStructFromCopy(&CPU, SnapCPU, COUNT(SnapCPU), local_cpu, version);
 
@@ -1583,13 +1637,17 @@ int S9xUnfreezeFromStream (STREAM stream)
 		struct SDMASnapshot	dma_snap;
 		UnfreezeStructFromCopy(&dma_snap, SnapDMA, COUNT(SnapDMA), local_dma, version);
 
-		memcpy(Memory.VRAM, local_vram, 0x10000);
+		if (local_vram)
+			memcpy(Memory.VRAM, local_vram, 0x10000);
 
-		memcpy(Memory.RAM, local_ram, 0x20000);
+		if (local_ram)
+			memcpy(Memory.RAM, local_ram, 0x20000);
 
-		memcpy(Memory.SRAM, local_sram, 0x20000);
+		if (local_sram)
+			memcpy(Memory.SRAM, local_sram, 0x20000);
 
-		memcpy(Memory.FillRAM, local_fillram, 0x8000);
+		if (local_fillram)
+			memcpy(Memory.FillRAM, local_fillram, 0x8000);
 
         if(version < SNAPSHOT_VERSION_BAPU) {
             printf("Using Blargg APU snapshot loading (snapshot version %d, current is %d)\n...", version, SNAPSHOT_VERSION);
@@ -1734,6 +1792,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 		if (local_msu1_data)
 			S9xMSU1PostLoadState();
 
+#if SAVE_SCREENSHOT
 		if (local_screenshot)
 		{
 			SnapshotScreenshotInfo	*ssi = new SnapshotScreenshotInfo;
@@ -1792,6 +1851,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 			for (uint32 y = 0; y < (uint32) (IMAGE_HEIGHT); y++)
 				memset(GFX.Screen + y * GFX.RealPPL, 0, GFX.RealPPL * 2);
 		}
+#endif
 	}
 
 	if (local_cpu)				delete [] local_cpu;
@@ -1987,9 +2047,54 @@ static void FreezeBlock (STREAM stream, const char *name, uint8 *block, int size
 	WRITE_STREAM(block, size, stream);
 }
 
+static bool CheckBlockName(STREAM stream, const char *name, int &len)
+{
+	char	buffer[16];
+	len = 0;
+	long	rewind = FIND_STREAM(stream);
+
+	size_t	l = READ_STREAM(buffer, 11, stream);
+	buffer[l] = 0;
+	REVERT_STREAM(stream, FIND_STREAM(stream) - l, 0);
+
+	if (buffer[4] == '-')
+	{
+		len = (((unsigned char)buffer[6]) << 24)
+			| (((unsigned char)buffer[7]) << 16)
+			| (((unsigned char)buffer[8]) << 8)
+			| (((unsigned char)buffer[9]) << 0);
+	}
+	else
+		len = atoi(buffer + 4);
+
+	if (l != 11 || strncmp(buffer, name, 3) != 0 || buffer[3] != ':')
+	{
+		return false;
+	}
+
+	if (len <= 0)
+	{
+		return false;
+	}
+
+	return true;
+}
+
+static void SkipBlockWithName(STREAM stream, const char *name)
+{
+	int len;
+	bool matchesName = CheckBlockName(stream, name, len);
+	if (matchesName)
+	{
+		long rewind = FIND_STREAM(stream);
+		rewind += len + 11;
+		REVERT_STREAM(stream, rewind, 0);
+	}
+}
+
 static int UnfreezeBlock (STREAM stream, const char *name, uint8 *block, int size)
 {
-	char	buffer[20];
+	char	buffer[16];
 	int		len = 0, rem = 0;
 	long	rewind = FIND_STREAM(stream);
 
@@ -2025,7 +2130,10 @@ static int UnfreezeBlock (STREAM stream, const char *name, uint8 *block, int siz
 		len = size;
 	}
 
+	#if FAST_SAVESTATES
+	#else
 	memset(block, 0, size);
+	#endif
 
 	if (READ_STREAM(block, len, stream) != len)
 	{
@@ -2051,6 +2159,13 @@ static int UnfreezeBlock (STREAM stream, const char *name, uint8 *block, int siz
 static int UnfreezeBlockCopy (STREAM stream, const char *name, uint8 **block, int size)
 {
 	int	result;
+
+	//check name first to avoid memory allocation
+	int blockLength;
+	if (!CheckBlockName(stream, name, blockLength))
+	{
+		return 0;
+	}
 
 	*block = new uint8[size];
 

--- a/snes9x.h
+++ b/snes9x.h
@@ -450,6 +450,9 @@ struct SSettings
 	bool8	UpAndDown;
 
 	bool8	OpenGLEnable;
+
+	bool8	FastSavestates;
+	bool8	HardDisableAudio;
 };
 
 struct SSNESGameFixes


### PR DESCRIPTION
I've added Audio/Video disable support, Fast Savestates, and Hard Audio Disable support to the emulator.

Audio/Video disable support will mute audio and disable video rendering.

Fast savestates do this:
* Update the VRAM, RAM, SRAM, Fill Ram buffers in place without using an allocation and copy, and a couple other bufffers too
* Remove memory clear of loaded blocks
* Replace a full reset with just PPU tile cache invalidation, it was the only thing I found in my brief testing that actually needed initialization to fix issues.

Additionally, I removed the misfeature that blacked out the screen when loading state due to a screenshot being absent from the savestate.

And Hard Audio Disable stops emulating the Audio DSP and keeps the SPC700 CPU running.