### PR TITLE
backport more irq fixes, libretro features

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -206,6 +206,7 @@
 
 static void S9xResetCPU (void);
 static void S9xSoftResetCPU (void);
+extern bool randomize_memory;
 
 
 static void S9xResetCPU (void)
@@ -229,6 +230,7 @@ static void S9xSoftResetCPU (void)
 	CPU.PCBase = NULL;
 	CPU.NMIPending = FALSE;
 	CPU.IRQLine = FALSE;
+	CPU.IRQTransition = FALSE;
 	CPU.IRQExternal = FALSE;
 	CPU.IRQPending = Timings.IRQPendCount;
 	CPU.MemSpeed = SLOW_ONE_CYCLE;
@@ -285,7 +287,14 @@ void S9xReset (void)
 	S9xResetSaveTimer(FALSE);
 	S9xResetLogger();
 
-	memset(Memory.RAM, 0x55, 0x20000);
+	if(!randomize_memory)
+		memset(Memory.RAM, 0x55, 0x20000);
+	else
+	{
+		srand(time(NULL));
+		for(int lcv=0; lcv<0x20000; lcv++)
+			Memory.RAM[lcv] = rand()%256;
+	}
 	memset(Memory.VRAM, 0x00, 0x10000);
 	memset(Memory.FillRAM, 0, 0x8000);
 
@@ -296,7 +305,7 @@ void S9xReset (void)
 	S9xResetPPU();
 	S9xResetDMA();
 	S9xResetAPU();
-	S9xResetMSU();
+    S9xResetMSU();
 
 	if (Settings.DSP)
 		S9xResetDSP();
@@ -333,7 +342,7 @@ void S9xSoftReset (void)
 	S9xSoftResetPPU();
 	S9xResetDMA();
 	S9xSoftResetAPU();
-	S9xResetMSU();
+    S9xResetMSU();
 
 	if (Settings.DSP)
 		S9xResetDSP();

--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -237,36 +237,39 @@ void S9xMainLoop (void)
 				{
 					CPU.WaitingForInterrupt = FALSE;
 					Registers.PCw++;
-					CPU.Cycles += 14;
+					CPU.Cycles += ONE_CYCLE;
 					while (CPU.Cycles >= CPU.NextEvent)
 						S9xDoHEventProcessing();
 				}
 
 				S9xOpcode_NMI();
-#ifdef CPU_OPCODE_INSTRUMENTATION
-            puts("** EXEC=NMI");
-#endif
 			}
 		}
 
-		if ((CPU.Cycles >= Timings.NextIRQTimer || CPU.IRQExternal) && !CPU.IRQLine)
+		if (CPU.IRQTransition)
+		{
+			if (CPU.WaitingForInterrupt)
+			{
+				CPU.WaitingForInterrupt = FALSE;
+				Registers.PCw++;
+				CPU.Cycles += ONE_CYCLE;
+				while (CPU.Cycles >= CPU.NextEvent)
+					S9xDoHEventProcessing();
+			}
+
+			S9xUpdateIRQPositions();
+			CPU.IRQPending = Timings.IRQPendCount;
+			CPU.IRQTransition = FALSE;
+			CPU.IRQLine = TRUE;
+		}
+
+		if ((CPU.Cycles >= Timings.NextIRQTimer || CPU.IRQExternal) && !CPU.IRQLine && !CPU.IRQTransition)
 		{
 			if (CPU.IRQPending)
 				CPU.IRQPending--;
 			else
 			{
-				if (CPU.WaitingForInterrupt)
-				{
-					CPU.WaitingForInterrupt = FALSE;
-					Registers.PCw++;
-					CPU.Cycles += 14;
-					while (CPU.Cycles >= CPU.NextEvent)
-						S9xDoHEventProcessing();
-				}
-
-				S9xUpdateIRQPositions();
-				CPU.IRQPending = Timings.IRQPendCount;
-				CPU.IRQLine = TRUE;
+				CPU.IRQTransition = TRUE;
 			}
 		}
 
@@ -331,9 +334,6 @@ void S9xMainLoop (void)
 				Opcodes = S9xOpcodesSlow;
 		}
 
-#ifdef CPU_OPCODE_INSTRUMENTATION
-      printf("EXEC=%.6X\n",Registers.PBPC);
-#endif
 		Registers.PCw++;
 		(*Opcodes[Op].S9xOpcode)();
 

--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -263,7 +263,7 @@ void S9xMainLoop (void)
 			CPU.IRQLine = TRUE;
 		}
 
-		if ((CPU.Cycles >= Timings.NextIRQTimer || CPU.IRQExternal) && !CPU.IRQLine && !CPU.IRQTransition)
+		if ((CPU.Cycles >= Timings.NextIRQTimer) && !CPU.IRQLine && !CPU.IRQTransition)
 		{
 			if (CPU.IRQPending)
 				CPU.IRQPending--;
@@ -273,7 +273,7 @@ void S9xMainLoop (void)
 			}
 		}
 
-		if (CPU.IRQLine && !CheckFlag(IRQ))
+		if ((CPU.IRQLine || CPU.IRQExternal) && !CheckFlag(IRQ))
 			S9xOpcode_IRQ();
 
 	#ifdef DEBUGGER

--- a/debug.cpp
+++ b/debug.cpp
@@ -887,7 +887,7 @@ static uint8 debug_cpu_op_print (char *Line, uint8 Bank, uint16 Address)
 			break;
 	}
 
-	sprintf(Line, "%-44s A:%04X X:%04X Y:%04X D:%04X DB:%02X S:%04X P:%c%c%c%c%c%c%c%c%c HC:%04ld VC:%03ld FC:%02d %03x",
+	sprintf(Line, "%-44s A:%04X X:%04X Y:%04X D:%04X DB:%02X S:%04X P:%c%c%c%c%c%c%c%c%c HC:%04ld VC:%03ld FC:%02d %03x %c %c%c",
 	        Line, Registers.A.W, Registers.X.W, Registers.Y.W,
 	        Registers.D.W, Registers.DB, Registers.S.W,
 	        CheckEmulation() ? 'E' : 'e',
@@ -902,7 +902,10 @@ static uint8 debug_cpu_op_print (char *Line, uint8 Bank, uint16 Address)
 	        (long) CPU.Cycles,
 	        (long) CPU.V_Counter,
 	        IPPU.FrameCount,
-	        (CPU.IRQExternal ? 0x100 : 0) | (PPU.HTimerEnabled ? 0x10 : 0) | (PPU.VTimerEnabled ? 0x01 : 0));
+	        (CPU.IRQExternal ? 0x100 : 0) | (PPU.HTimerEnabled ? 0x10 : 0) | (PPU.VTimerEnabled ? 0x01 : 0),
+	        CPU.NMIPending ? 'N' : '.',
+	        CPU.IRQTransition ? 'T' : ' ',
+	        CPU.IRQLine ? 'L' : ' ');
 
 	return (Size);
 }
@@ -1646,14 +1649,8 @@ static void debug_process_command (char *Line)
 
 	if (*Line == 'a')
 	{
-		printf("APU in-ports : %02X %02X %02X %02X\n", IAPU.RAM[0xF4], IAPU.RAM[0xF5], IAPU.RAM[0xF6], IAPU.RAM[0xF7]);
-		printf("APU out-ports: %02X %02X %02X %02X\n", APU.OutPorts[0], APU.OutPorts[1], APU.OutPorts[2], APU.OutPorts[3]);
-		printf("ROM/RAM switch: %s\n", (IAPU.RAM[0xf1] & 0x80) ? "ROM" : "RAM");
-
-		for (int i = 0; i < 3; i++)
-			if (APU.TimerEnabled[i])
-				printf("Timer%d enabled, Value: 0x%03X, 4-bit: 0x%02X, Target: 0x%03X\n",
-				       i, APU.Timer[i], IAPU.RAM[0xfd + i], APU.TimerTarget[i]);
+		printf("S-CPU-side ports S-CPU writes these, S-SMP reads: %02X %02X %02X %02X\n", SNES::cpu.port_read(0), SNES::cpu.port_read(1), SNES::cpu.port_read(2), SNES::cpu.port_read(3));
+		printf("S-SMP-side ports S-SMP writes these, S-CPU reads: %02X %02X %02X %02X\n", SNES::smp.port_read(0), SNES::smp.port_read(1), SNES::smp.port_read(2), SNES::smp.port_read(3));
 	}
 
 	if (*Line == 'P')

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -339,7 +339,7 @@ void S9xBuildDirectColourMaps (void)
 void S9xStartScreenRefresh (void)
 {
 	GFX.InterlaceFrame = !GFX.InterlaceFrame;
-	
+
 	if (IPPU.RenderThisFrame)
 	{
 		if (!GFX.DoInterlace || !GFX.InterlaceFrame)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -45,6 +45,7 @@ char g_rom_dir[1024];
 char g_basename[1024];
 bool overclock_cycles = false;
 bool reduce_sprite_flicker = false;
+bool randomize_memory = false;
 int one_c, slow_one_c, two_c;
 
 retro_log_printf_t log_cb = NULL;

--- a/ppu.h
+++ b/ppu.h
@@ -639,10 +639,10 @@ static inline void REGISTER_2118_linear (uint8 Byte)
         }
 #endif
 
+
 static inline void REGISTER_2119 (uint8 Byte)
 {
 	CHECK_INBLANK();
-
 	uint32	address;
 
 	if (PPU.VMA.FullGraphicCount)


### PR DESCRIPTION
backport:
IRQExternal isn't susceptible to same delays. (SuperFX)
Fix case when vtimer and htimer are enabled and the timer would have triggered earlier on the current line.
irq transitions
misc cleanup

libretro:
memory randomization
runahead core workaround (crop)
