### PR TITLE
Prevent calling retro_run if no rom is loaded

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1028,6 +1028,9 @@ static void report_buttons()
 
 void retro_run()
 {
+   //sanity check to prevent infinite loop inside emulator
+   if (!rom_loaded) return;
+
    static uint16 height = PPU.ScreenHeight;
    bool updated = false;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)


### PR DESCRIPTION
Prevent calling retro_run if no rom is loaded
It gets into an infinite loop if you proceed without a rom loaded.