### PR TITLE
 backport irq,opt,msu1 fixes + libretro changes

### DIFF
--- a/cpuexec.cpp
+++ b/cpuexec.cpp
@@ -257,7 +257,7 @@ void S9xMainLoop (void)
 					S9xDoHEventProcessing();
 			}
 
-			S9xUpdateIRQPositions();
+
 			CPU.IRQPending = Timings.IRQPendCount;
 			CPU.IRQTransition = FALSE;
 			CPU.IRQLine = TRUE;
@@ -265,6 +265,8 @@ void S9xMainLoop (void)
 
 		if ((CPU.Cycles >= Timings.NextIRQTimer) && !CPU.IRQLine && !CPU.IRQTransition)
 		{
+			S9xUpdateIRQPositions(false);
+
 			if (CPU.IRQPending)
 				CPU.IRQPending--;
 			else

--- a/gfx.cpp
+++ b/gfx.cpp
@@ -1500,6 +1500,7 @@ static void DrawBackgroundOffset (int bg, uint8 Zh, uint8 Zl, int VOffOff)
 
 	int	OffsetMask   = (BG.TileSizeH   == 16) ? 0x3ff : 0x1ff;
 	int	OffsetShift  = (BG.TileSizeV   == 16) ? 4 : 3;
+	int	Offset2Mask  = (BG.OffsetSizeH == 16) ? 0x3ff : 0x1ff;
 	int	Offset2Shift = (BG.OffsetSizeV == 16) ? 4 : 3;
 	int	OffsetEnableMask = 0x2000 << bg;
 	int	PixWidth = IPPU.DoubleWidthPixels ? 2 : 1;
@@ -1565,7 +1566,7 @@ static void DrawBackgroundOffset (int bg, uint8 Zh, uint8 Zl, int VOffOff)
 				}
 				else
 				{
-					int HOffTile = (((Left + (HScroll & 7)) - 8) + (HOff & ~7)) >> 3;
+					int HOffTile = ((HOff + Left - 1) & Offset2Mask) >> 3;
 
 					if (BG.OffsetSizeH == 8)
 					{

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -130,6 +130,7 @@ void retro_set_environment(retro_environment_t cb)
       { "snes9x_overclock", "SuperFX Frequency; 10MHz|20MHz|40MHz|60MHz|80MHz|100MHz" },
       { "snes9x_overclock_cycles", "Reduce Slowdown (Hack, Unsafe); disabled|compatible|max" },
       { "snes9x_reduce_sprite_flicker", "Reduce Flickering (Hack, Unsafe); disabled|enabled" },
+      { "snes9x_randomize_memory", "Randomize Memory (Unsafe); disabled|enabled" },
       { "snes9x_layer_1", "Show layer 1; enabled|disabled" },
       { "snes9x_layer_2", "Show layer 2; enabled|disabled" },
       { "snes9x_layer_3", "Show layer 3; enabled|disabled" },
@@ -245,6 +246,17 @@ static void update_variables(void)
           reduce_sprite_flicker = false;
       }
 
+   var.key = "snes9x_randomize_memory";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      {
+        if (strcmp(var.value, "enabled") == 0)
+          randomize_memory = true;
+        else
+          randomize_memory = false;
+      }
+
    int disabled_channels=0;
    strcpy(key, "snes9x_sndchan_x");
    var.key=key;
@@ -321,7 +333,8 @@ static void update_variables(void)
    if (reset_sfx)
       S9xResetSuperFX();
 
-   if (geometry_update)
+  // hack: runahead cores (crop option)
+   //if (geometry_update)
      update_geometry();
 }
 

--- a/memmap.cpp
+++ b/memmap.cpp
@@ -3879,6 +3879,26 @@ void CMemory::ApplyROMFixes (void)
 		}
 	}
 
+	if (!Settings.DisableGameSpecificHacks)
+	{
+		// irq cli problem
+		if (match_nn("MARKOS MAGIC FOOTBALL"))
+		{
+			unsigned char patch1[] = {0x78,0x08,0xC2,0x30,0x48,0xDA,0x5A,0x8B,0x0B,0xE2,0x30};
+			unsigned char patch2[] = {0xC2,0x30,0x2B,0xAB,0x7A,0xFA,0x68,0x28,0x58,0x40};
+			unsigned char patch3[] = {0xC2,0x30,0x48,0xDA,0x5A,0x8B,0x0B,0xE2,0x30,0x4B,0xAB};
+			
+			if((memcmp(patch1,Memory.ROM+0x9a3,sizeof(patch1))==0) &&
+				 (memcmp(patch2,Memory.ROM+0x9b5,sizeof(patch2))==0))
+			{
+				// phk - plb
+				memcpy(ROM+0x9a3,patch3,sizeof(patch3));
+				Memory.ROM[0x9bc]=0x40;
+			}
+		}
+	}
+
+
 	//// SRAM initial value
 
 	if (!Settings.DisableGameSpecificHacks)

--- a/ppu.cpp
+++ b/ppu.cpp
@@ -303,7 +303,7 @@ static int CyclesUntilNext (int hc, int vc)
 	return total;
 }
 
-void S9xUpdateIRQPositions (void)
+void S9xUpdateIRQPositions (bool initial)
 {
 	PPU.HTimerPosition = PPU.IRQHBeamPos * ONE_DOT_CYCLE + Timings.IRQTriggerCycles;
 	if (Timings.H_Max == Timings.H_Max_Master)	// 1364
@@ -337,7 +337,7 @@ void S9xUpdateIRQPositions (void)
 	}
 	else if (!PPU.HTimerEnabled && PPU.VTimerEnabled)
 	{
-		if (CPU.V_Counter == PPU.VTimerPosition)
+		if (CPU.V_Counter == PPU.VTimerPosition && initial)
 			Timings.NextIRQTimer = Timings.IRQTriggerCycles;
 		else
 			Timings.NextIRQTimer = CyclesUntilNext (Timings.IRQTriggerCycles, PPU.VTimerPosition);
@@ -348,8 +348,8 @@ void S9xUpdateIRQPositions (void)
 	}
 
 #ifdef DEBUGGER
-	S9xTraceFormattedMessage("--- IRQ Timer set  HTimer:%d Pos:%04d  VTimer:%d Pos:%03d",
-		PPU.HTimerEnabled, PPU.HTimerPosition, PPU.VTimerEnabled, PPU.VTimerPosition);
+	S9xTraceFormattedMessage("--- IRQ Timer set %d cycles HTimer:%d Pos:%04d->%04d  VTimer:%d Pos:%03d->%03d",
+		Timings.NextIRQTimer, PPU.HTimerEnabled, PPU.IRQHBeamPos, PPU.HTimerPosition, PPU.VTimerEnabled, PPU.IRQVBeamPos, PPU.VTimerPosition);
 #endif
 }
 
@@ -1565,7 +1565,7 @@ void S9xSetCPU (uint8 Byte, uint16 Address)
 					CPU.IRQTransition = FALSE;
 				}
 
-				S9xUpdateIRQPositions();
+				S9xUpdateIRQPositions(true);
 
 				// NMI can trigger immediately during VBlank as long as NMI_read ($4210) wasn't cleard.
 				if ((Byte & 0x80) && !(Memory.FillRAM[0x4200] & 0x80) &&
@@ -1632,7 +1632,7 @@ if (Settings.TraceHCEvent)
 				pos = PPU.IRQHBeamPos;
 				PPU.IRQHBeamPos = (PPU.IRQHBeamPos & 0xff00) | Byte;
 				if (PPU.IRQHBeamPos != pos)
-					S9xUpdateIRQPositions();
+					S9xUpdateIRQPositions(false);
 			#ifdef DEBUGGER
 				missing.hirq_pos = PPU.IRQHBeamPos;
 			#endif
@@ -1642,7 +1642,7 @@ if (Settings.TraceHCEvent)
 				pos = PPU.IRQHBeamPos;
 				PPU.IRQHBeamPos = (PPU.IRQHBeamPos & 0xff) | ((Byte & 1) << 8);
 				if (PPU.IRQHBeamPos != pos)
-					S9xUpdateIRQPositions();
+					S9xUpdateIRQPositions(false);
 			#ifdef DEBUGGER
 				missing.hirq_pos = PPU.IRQHBeamPos;
 			#endif
@@ -1652,7 +1652,7 @@ if (Settings.TraceHCEvent)
 				pos = PPU.IRQVBeamPos;
 				PPU.IRQVBeamPos = (PPU.IRQVBeamPos & 0xff00) | Byte;
 				if (PPU.IRQVBeamPos != pos)
-					S9xUpdateIRQPositions();
+					S9xUpdateIRQPositions(true);
 			#ifdef DEBUGGER
 				missing.virq_pos = PPU.IRQVBeamPos;
 			#endif
@@ -1662,7 +1662,7 @@ if (Settings.TraceHCEvent)
 				pos = PPU.IRQVBeamPos;
 				PPU.IRQVBeamPos = (PPU.IRQVBeamPos & 0xff) | ((Byte & 1) << 8);
 				if (PPU.IRQVBeamPos != pos)
-					S9xUpdateIRQPositions();
+					S9xUpdateIRQPositions(true);
 			#ifdef DEBUGGER
 				missing.virq_pos = PPU.IRQVBeamPos;
 			#endif
@@ -1841,7 +1841,7 @@ uint8 S9xGetCPU (uint16 Address)
 				byte = CPU.IRQLine ? 0x80 : 0;
 				CPU.IRQLine = FALSE;
 				CPU.IRQTransition = FALSE;
-				S9xUpdateIRQPositions();
+				S9xUpdateIRQPositions(false);
 
 				return (byte | (OpenBus & 0x7f));
 

--- a/ppu.h
+++ b/ppu.h
@@ -390,7 +390,7 @@ void S9xSetPPU (uint8, uint16);
 uint8 S9xGetPPU (uint16);
 void S9xSetCPU (uint8, uint16);
 uint8 S9xGetCPU (uint16);
-void S9xUpdateIRQPositions (void);
+void S9xUpdateIRQPositions (bool initial);
 void S9xFixColourBrightness (void);
 void S9xDoAutoJoypad (void);
 

--- a/snapshot.cpp
+++ b/snapshot.cpp
@@ -1748,7 +1748,7 @@ int S9xUnfreezeFromStream (STREAM stream)
 		ICPU.ShiftedDB = Registers.DB << 16;
 		S9xSetPCBase(Registers.PBPC);
 		S9xUnpackStatus();
-		S9xUpdateIRQPositions();
+		S9xUpdateIRQPositions(false);
 		S9xFixCycles();
 
 		for (int d = 0; d < 8; d++)


### PR DESCRIPTION
backport:
Don't schedule recurring vtimer for current line immediately.
Use older calculation for non-mosaic offset-per-tile mode.
Clean up S9xMSU1Generate.

libretro:
randomize memory
runahead hack (crop option)
Marko's Magic Football irq hack