### PR TITLE
missing part of "Backport irq, openbus fixes"

### DIFF
--- a/snes9x.h
+++ b/snes9x.h
@@ -338,6 +338,13 @@ enum
 	HC_WRAM_REFRESH_EVENT = 6
 };
 
+enum
+{
+	IRQ_NONE = 0,
+	IRQ_SET_FLAG = 1,
+	IRQ_CLEAR_FLAG = 2
+};
+
 struct STimings
 {
 	int32	H_Max_Master;
@@ -356,7 +363,7 @@ struct STimings
 	bool8	InterlaceField;
 	int32	DMACPUSync;		// The cycles to synchronize DMA and CPU. Snes9x cannot emulate correctly.
 	int32	NMIDMADelay;	// The delay of NMI trigger after DMA transfers. Snes9x cannot emulate correctly.
-	int32	IRQPendCount;	// This value is just a hack.
+	int32	IRQFlagChanging;	// This value is just a hack.
 	int32	APUSpeedup;
 	bool8	APUAllowTimeOverflow;
 };


### PR DESCRIPTION
change missing from https://github.com/libretro/snes9x/commit/d31cda9b3b933b8639680c2d1287f36ed4c651c1