### PR TITLE
libretro: Use -O3 instead of -O2.

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -547,8 +547,8 @@ ifeq ($(DEBUG), 1)
       CXXFLAGS += -O0 -g -DDEBUG
    endif
 else
-   CFLAGS += -O2 -DNDEBUG
-   CXXFLAGS += -O2 -DNDEBUG
+   CFLAGS += -O3 -DNDEBUG
+   CXXFLAGS += -O3 -DNDEBUG
 
    ifneq (,$(findstring msvc,$(platform)))
       ifeq ($(STATIC_LINKING),1)


### PR DESCRIPTION
As suggested in comment https://github.com/snes9xgit/snes9x/issues/461#issuecomment-447937751.

Note if this breaks any games I hope snes9x devs can take a look at the issues.