### PR TITLE
Add "Extreme" option to cycle overclock setting

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -619,13 +619,11 @@ else
 all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
-	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
 	+$(LD) $(fpic) $(SHARED) $(LINKOUT)$@ $(OBJECTS) $(LDFLAGS) $(LIBS)
 endif
-	@echo "** BUILD SUCCESSFUL! GG NO RE **"
 
 %.o: %.cpp 
 	$(CXX) $(INCFLAGS) $(CPPFLAGS) $(CXXFLAGS) -c $(OBJOUT)$@ $<

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -619,11 +619,13 @@ else
 all: $(TARGET)
 
 $(TARGET): $(OBJECTS)
+	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJECTS)
 else
 	+$(LD) $(fpic) $(SHARED) $(LINKOUT)$@ $(OBJECTS) $(LDFLAGS) $(LIBS)
 endif
+	@echo "** BUILD SUCCESSFUL! GG NO RE **"
 
 %.o: %.cpp 
 	$(CXX) $(INCFLAGS) $(CPPFLAGS) $(CXXFLAGS) -c $(OBJOUT)$@ $<

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -174,7 +174,7 @@ void retro_set_environment(retro_environment_t cb)
         // Adding more variables and rearranging them is safe.
         { "snes9x_up_down_allowed", "Allow Opposing Directions; disabled|enabled" },
         { "snes9x_overclock_superfx", "SuperFX Overclocking; 100%|150%|200%|250%|300%|350%|400%|450%|500%|50%|60%|70%|80%|90%" },
-        { "snes9x_overclock_cycles", "Reduce Slowdown (Hack, Unsafe); disabled|light|compatible|max" },
+        { "snes9x_overclock_cycles", "Reduce Slowdown (Hack, Unsafe); disabled|light|compatible|max|extreme" },
         { "snes9x_reduce_sprite_flicker", "Reduce Flickering (Hack, Unsafe); disabled|enabled" },
         { "snes9x_randomize_memory", "Randomize Memory (Unsafe); disabled|enabled" },
         { "snes9x_hires_blend", "Hires Blending; disabled|merge|blur" },
@@ -413,7 +413,13 @@ static void update_variables(void)
     var.value=NULL;
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
     {
-        if (strcmp(var.value, "max") == 0)
+        if (strcmp(var.value, "extreme") == 0)
+	{
+            Settings.OneClockCycle      = 1;
+            Settings.OneSlowClockCycle  = 1;
+	    Settings.TwoClockCycles     = 1;
+	}
+	else if (strcmp(var.value, "max") == 0)
         {
             Settings.OneClockCycle      = 3;
             Settings.OneSlowClockCycle  = 3;


### PR DESCRIPTION
Adds an "Extreme" overclock setting that is the equivelent of running the SNES without a divided clock speed. May most likely completely eliminate slowdown in the most intensive SNES game, including Gradius III and Rudra no Hihou (During a few spell animations). May also allow the removal of slowdown in parts of the second and third routes of Star Fox that still have it even at 500% SuperFX speed and Max overclock setting. Can also allow double speed in Star Ocean (during battles), if desired. In general, games that run without crashing will have absolutely no slowdown, no matter the game.

This is a duplicate of a PR I made, taking the proper steps and precautions this time.