### PR TITLE
Dynamically build a controller info table based on connected devices

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -821,17 +821,17 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
                 break;
             case RETRO_DEVICE_JOYPAD_MULTITAP:
                 S9xSetController(port, CTL_MP5, port * offset, port * offset + 1, port * offset + 2, port * offset + 3);
-                if ( port < 2 )
+                if ( port != 1 )
                 {
 	                snes_devices[port] = RETRO_DEVICE_JOYPAD_MULTITAP;
-				}
-				else
-				{
-					if (log_cb)
-						log_cb(RETRO_LOG_ERROR, "Invalid multitap assignment to port %d, must be port 0 or 1.\n", port);
-					S9xSetController(port, CTL_NONE, 0, 0, 0, 0);
-					snes_devices[port] = RETRO_DEVICE_NONE;
-				}
+                }
+                else
+                {
+                    if (log_cb)
+                        log_cb(RETRO_LOG_ERROR, "Invalid multitap assignment to port %d, must be port 1.\n", port);
+                    S9xSetController(port, CTL_NONE, 0, 0, 0, 0);
+                    snes_devices[port] = RETRO_DEVICE_NONE;
+                }
                 break;
             case RETRO_DEVICE_MOUSE:
                 S9xSetController(port, CTL_MOUSE, port, 0, 0, 0);

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -189,7 +189,7 @@ static void submit_ports_table()
     retro_controller_info* p = ports_table;
     
     p->types = port_1;
-    p->num_types = 4;
+    p->num_types = 3;
     ++p;
 
     p->types = port_2;


### PR DESCRIPTION
Currently the table sent via RETRO_ENVIRONMENT_SET_CONTROLLER_INFO is fixed and offers all possible combinations of devices. Because of this, it is not possible for the front-end to know how many controller ports are being emulated.

I've changed the code so that the table is built dynamically based on whether a multi-tap or Justifier is plugged into the second SNES controller port, and if so additional table entries are added to raise the total number of ports to 5 or 3 respectively.

I've tested with NBA Live '98 and five controllers are still functioning.

NOTE: This patch removes the ability to add a multitap into the first controller port. Not something required for commercial software, but apparently some homebrew may use it (https://nintendo.fandom.com/wiki/Super_Multitap)
