### PR TITLE
Touchscreen Lightgun Support

### DIFF
--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -246,6 +246,7 @@ extern "C" {
 #define RETRO_DEVICE_ID_POINTER_X         0
 #define RETRO_DEVICE_ID_POINTER_Y         1
 #define RETRO_DEVICE_ID_POINTER_PRESSED   2
+#define RETRO_DEVICE_ID_POINTER_COUNT     3
 
 /* Returned from retro_get_region(). */
 #define RETRO_REGION_NTSC  0


### PR DESCRIPTION
Adds touchscreen lightgun support:

Super Scope:
- single touch = trigger
- double touch = cursor
- triple touch = turbo
- quad touch = start

Justifier:
- single touch = trigger
- double touch = reload
- triple touch = start

Touchscreen lightgun can be enabled in Core Options, under "Lightgun Mode".

Also added a core option for reversing super scope trigger/cursor buttons to support games like Operation Thunderbolt and T2: The Arcade Game where cursor is held down for primary fire. This lets you hold a single finger down on the screen to fire, and double tap for secondary fire.

Note: multi-touch requires that the input driver for the system supports `RETRO_DEVICE_ID_POINTER_COUNT` - currently supported in iOS and Android