### PR TITLE
Add BOM marker and MSVC2010-2013 UTF-8 fix for `libretro_core_options.h` (Turkish text)

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -1,5 +1,11 @@
-#ifndef LIBRETRO_CORE_OPTIONS_H__
+﻿#ifndef LIBRETRO_CORE_OPTIONS_H__
 #define LIBRETRO_CORE_OPTIONS_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
The file `libretro_core_options.h` contains Turkish characters, and must be built in UTF-8 mode on MSVC now.

This will add the BOM marker, and include a MSVC 2010-2013 specific fix for execution codepage.