### PR TITLE
(Core Options) Fix UTF-8 compilation issues, update 'libretro_core_options.h' to v1.3 format

### DIFF
--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1117,7 +1117,7 @@ enum retro_mod
                                             * This may be still be done regardless of the core options
                                             * interface version.
                                             *
-                                            * If version is 1 however, core options may instead be set by
+                                            * If version is >= 1 however, core options may instead be set by
                                             * passing an array of retro_core_option_definition structs to
                                             * RETRO_ENVIRONMENT_SET_CORE_OPTIONS, or a 2D array of
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
@@ -1132,8 +1132,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -1169,8 +1169,6 @@ enum retro_mod
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
                                             *
-                                            * First entry should be treated as a default.
-                                            *
                                             * Example entry:
                                             * {
                                             *     "foo_option",
@@ -1196,8 +1194,8 @@ enum retro_mod
                                             * GET_VARIABLE.
                                             * This allows the frontend to present these variables to
                                             * a user dynamically.
-                                            * This should only be called if RETRO_ENVIRONMENT_GET_ENHANCED_CORE_OPTIONS
-                                            * returns an API version of 1.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
@@ -2504,8 +2502,20 @@ struct retro_core_option_display
 };
 
 /* Maximum number of values permitted for a core option
- * NOTE: This may be increased on a core-by-core basis
- * if required (doing so has no effect on the frontend) */
+ * > Note: We have to set a maximum value due the limitations
+ *   of the C language - i.e. it is not possible to create an
+ *   array of structs each containing a variable sized array,
+ *   so the retro_core_option_definition values array must
+ *   have a fixed size. The size limit of 128 is a balancing
+ *   act - it needs to be large enough to support all 'sane'
+ *   core options, but setting it too large may impact low memory
+ *   platforms. In practise, if a core option has more than
+ *   128 values then the implementation is likely flawed.
+ *   To quote the above API reference:
+ *      "The number of possible options should be very limited
+ *       i.e. it should be feasible to cycle through options
+ *       without a keyboard."
+ */
 #define RETRO_NUM_CORE_OPTION_VALUES_MAX 128
 
 struct retro_core_option_value

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -1,15 +1,13 @@
-#ifndef LIBRETRO_CORE_OPTIONS_H__
-#define LIBRETRO_CORE_OPTIONS_H__
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
 
-#include <stdlib.h>
-#include <string.h>
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
 
 #include <libretro.h>
-#include <retro_inline.h>
-
-#ifndef HAVE_NO_LANGEXTRA
-#include "libretro_core_options_intl.h"
-#endif
 
 /*
  ********************************
@@ -39,27 +37,53 @@ extern "C" {
  ********************************
 */
 
-/* RETRO_LANGUAGE_ENGLISH */
+/* RETRO_LANGUAGE_JAPANESE */
 
-/* Default language:
- * - All other languages must include the same keys and values
- * - Will be used as a fallback in the event that frontend language
- *   is not available
- * - Will be used as a fallback for any missing entries in
- *   frontend language definition */
+/* RETRO_LANGUAGE_FRENCH */
 
-struct retro_core_option_definition option_defs_us[] = {
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+struct retro_core_option_definition option_defs_tr[] = {
 
    /* These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
     * Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
     * Adding more variables and rearranging them is safe. */
-
-   {
-      "snes9x_region",
-      "Console Region (Reload Core)",
-      "Specify which region the system is from. 'PAL' is 50hz, 'NTSC' is 60hz. Games will run faster or slower than normal if the incorrect region is selected.",
       {
-         { "auto", "Auto" },
+      "snes9x_region",
+      "Konsol Bölgesi (Core Yenilenir)",
+      "Sistemin hangi bölgeden olduğunu belirtir.. 'PAL' 50hz'dir, 'NTSC' ise 60hz. Yanlış bölge seçiliyse, oyunlar normalden daha hızlı veya daha yavaş çalışacaktır.",
+      {
+         { "auto", "Otomatik" },
          { "ntsc", "NTSC" },
          { "pal",  "PAL" },
          { NULL, NULL},
@@ -68,12 +92,12 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_aspect",
-      "Preferred Aspect Ratio",
-      "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
+      "Tercih Edilen En Boy Oranı",
+      "Tercih edilen içerik en boy oranını seçin. Bu, yalnızca RetroArch’ın en boy oranı Video ayarlarında 'Core tarafından' olarak ayarlandığında uygulanacaktır.",
       {
          { "4:3",         NULL },
-         { "uncorrected", "Uncorrected" },
-         { "auto",        "Auto" },
+         { "uncorrected", "Düzeltilmemiş" },
+         { "auto",        "Otomatik" },
          { "ntsc",        "NTSC" },
          { "pal",         "PAL" },
          { NULL, NULL},
@@ -82,20 +106,20 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_overscan",
-      "Crop Overscan",
-      "Remove the ~8 pixel borders at the top and bottom of the screen, typically unused by games and hidden by the bezel of a standard-definition television. 'Auto' will attempt to detect and crop overscan based on the current content.",
+      "Aşırı Taramayı Kırp",
+      "Ekranın üst ve alt kısmındaki ~8 piksel sınırlarını, tipik olarak standart çözünürlüklü bir televizyondakini kaldırır. 'Otomatik' ise geçerli içeriğe bağlı olarak aşırı taramayı algılamaya ve kırpmaya çalışacaktır.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { "auto",     "Auto" },
+         { "auto",     "Otomatik" },
          { NULL, NULL},
       },
       "enabled"
    },
    {
       "snes9x_gfx_hires",
-      "Enable Hi-Res Mode",
-      "Allow games to switch to hi-res mode (512x448) or force all content to output at 256x224 (with crushed pixels).",
+      "Hi-Res Modunu Etkinleştir",
+      "Oyunların hi-res moduna (512x448) geçmesine izin verir veya tüm içeriği 256x224'te (ezilmiş piksellerle) çıkmaya zorlar.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -105,20 +129,20 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_hires_blend",
-      "Hi-Res Blending",
-      "Blend adjacent pixels when game switches to hi-res mode (512x448). Required for certain games that use hi-res mode to produce transparency effects (Kirby's Dream Land, Jurassic Park...).",
+      "Hi-Res Karışımı",
+      "Oyun hi-res moduna geçtiğinde pikselleri karıştırır (512x448). Şeffaflık efektleri üretmek için hi-res modunu kullanan bazı oyunlar için gereklidir (Kirby's Dream Land, Jurassic Park ...).",
       {
          { "disabled", NULL },
-         { "merge",    "Merge" },
-         { "blur",     "Blur" },
+         { "merge",    "Birlşetir" },
+         { "blur",     "Bulanıklaştır" },
          { NULL, NULL},
       },
       "disabled"
    },
    {
       "snes9x_blargg",
-      "Blargg NTSC Filter",
-      "Apply a video filter to mimic various NTSC TV signals.",
+      "Blargg NTSC Filtresi",
+      "Çeşitli NTSC TV sinyallerini taklit etmek için bir video filtresi uygular.",
       {
          { "disabled",   NULL },
          { "monochrome", "Monochrome" },
@@ -132,13 +156,13 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_audio_interpolation",
-      "Audio Interpolation",
-      "Apply an audio filter. 'Gaussian' reproduces the bass-heavy sound of the original hardware. 'Cubic' and 'Sinc' are less accurate, and preserve more of the high range.",
+      "Ses Enterpolasyonu",
+      "Belirtilen ses filtresini uygular. 'Gaussian', orijinal donanımın bas ağırlıklı sesini üretir. 'Cubic' ve 'Sinc' daha az doğrudur ve daha fazla aralığı korur.",
       {
          { "gaussian", "Gaussian" },
          { "cubic",    "Cubic" },
          { "sinc",     "Sinc" },
-         { "none",     "None" },
+         { "none",     "Hiçbiri" },
          { "linear",   "Linear" },
          { NULL, NULL},
       },
@@ -146,8 +170,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_up_down_allowed",
-      "Allow Opposing Directions",
-      "Enabling this will allow pressing / quickly alternating / holding both left and right (or up and down) directions at the same time. This may cause movement-based glitches.",
+      "Karşı Yönlere İzin Ver",
+      "Bunu etkinleştirmek aynı anda hem sola hem de sağa (veya yukarı ve aşağı) yönlere basma / hızlı değiştirme / tutma imkanı sağlar. Bu harekete dayalı hatalara neden olabilir.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -157,8 +181,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_overclock_superfx",
-      "SuperFX Overclocking",
-      "SuperFX coprocessor frequency multiplier. Can improve frame rate or cause timing errors. Values under 100% can improve game performance on slow devices.",
+      "SuperFX Hız Aşırtma",
+      "SuperFX işlemcisi frekans çarpanıdır. Kare hızını artırabilir veya zamanlama hatalarına neden olabilir. % 100'ün altındaki değerler yavaş cihazlarda oyun performansını artırabilir.",
       {
          { "50%",  NULL },
          { "60%",  NULL },
@@ -180,21 +204,21 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_overclock_cycles",
-      "Reduce Slowdown (Hack, Unsafe)",
-      "Overclock SNES CPU. May cause games to crash! Use 'Light' for shorter loading times, 'Compatible' for most games exhibiting slowdown and 'Max' only if absolutely required (Gradius 3, Super R-type...).",
+      "Yavaşlamayı Azalt (Hack, Güvensiz)",
+      "SNES İşlemcisi için hız aşırtmadır. Oyunların çökmesine neden olabilir! Daha kısa yükleme süreleri için 'Hafif'i, yavaşlama gösteren oyunların çoğunda' Uyumlu 've yalnızca kesinlikle gerekliyse' Maks 'kullanın (Gradius 3, Süper R tipi ...).",
       {
          { "disabled",   NULL },
-         { "light",      "Light" },
-         { "compatible", "Compatible" },
-         { "max",        "Max" },
+         { "light",      "Hafif" },
+         { "compatible", "Uyumlu" },
+         { "max",        "Maks" },
          { NULL, NULL},
       },
       "disabled"
    },
    {
       "snes9x_reduce_sprite_flicker",
-      "Reduce Flickering (Hack, Unsafe)",
-      "Increases number of sprites that can be drawn simultaneously on screen.",
+      "Kırılmayı Azalt (Hack, Güvensiz)",
+      "Ekranda aynı anda çizilebilen sprite sayısını arttırır.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -204,8 +228,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_randomize_memory",
-      "Randomize Memory (Unsafe)",
-      "Randomizes system RAM upon start-up. Some games such as 'Super Off Road' use system RAM as a random number generator for item placement and AI behavior, to make gameplay more unpredictable.",
+      "Belleği Rastgele Kıl (Güvensiz)",
+      "Başlatıldığında sistem RAM'ını rastgele ayarlar. 'Super Off Road' gibi bazı oyunlar, oyunu daha öngörülemeyen hale getirmek için öğe yerleştirme ve AI davranışı için rastgele sayı üreticisi olarak sistem RAM'ini kullanır.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -215,8 +239,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_block_invalid_vram_access",
-      "Block Invalid VRAM Access",
-      "Some homebrew/ROM hacks require this option to be disabled for correct operation.",
+      "Geçersiz VRAM Erişimini Engelle",
+      "Bazı Homebrew/ROM'lar, doğru işlem için bu seçeneğin devre dışı bırakılmasını gerektirir.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -226,8 +250,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_echo_buffer_hack",
-      "Echo Buffer Hack (Unsafe, only enable for old addmusic hacks)",
-      "Some homebrew/ROM hacks require this option to be enabled for correct operation.",
+      "Eko Tampon Hack (Güvenli değil, yalnızca eski addmusic için etkinleştirin)",
+      "Bazı Homebrew/ROM'lar, doğru işlem için bu seçeneğin devre dışı bırakılmasını gerektirir.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -237,8 +261,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_show_lightgun_settings",
-      "Show Light Gun Settings",
-      "Enable configuration of Super Scope / Justifier / M.A.C.S. rifle input. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      "Light Gun Ayarlarını Göster",
+      "Super Scope / Justifier / M.A.C.S. için tüfek girişi yapılandırmasını etkinleştir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün açılması gerekir.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -248,19 +272,19 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_lightgun_mode",
-      "Light Gun Mode",
-      "Use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
+      "Light Gun Modu",
+      "Fare kontrollü 'Light Gun' veya 'Dokunmatik Ekran' girişini kullanın.",
       {
          { "Lightgun",    "Light Gun" },
-         { "Touchscreen", NULL },
+         { "Touchscreen", "Dokunmatik Ekran" },
          { NULL, NULL},
       },
       "Lightgun"
    },
    {
       "snes9x_superscope_reverse_buttons",
-      "Super Scope Reverse Trigger Buttons",
-      "Swap the positions of the Super Scope 'Fire' and 'Cursor' buttons.",
+      "Super Scope Ters Tetik Düğmeleri",
+      "Süper Scope için 'Ateş' ve 'İmleç' butonlarının pozisyonlarını değiştir.",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -270,8 +294,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_superscope_crosshair",
-      "Super Scope Crosshair",
-      "Change the crosshair size on screen.",
+      "Super Scope İmkeç",
+      "Ekrandaki imleç işaretini değiştirin.",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -296,8 +320,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_superscope_color",
-      "Super Scope Color",
-      "Change the crosshair color on screen.",
+      "Super Scope Rengi",
+      "Ekrandaki imleç işaretinin rengini değiştirin.",
       {
          { "White",            NULL },
          { "White (blend)",    NULL },
@@ -335,8 +359,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_justifier1_crosshair",
-      "Justifier 1 Crosshair",
-      "Change the crosshair size on screen.",
+      "Justifier 1 İmleci",
+      "Ekrandaki imleç işaretinin boyutunu değiştirin.",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -361,8 +385,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_justifier1_color",
-      "Justifier 1 Color",
-      "Change the crosshair color on screen.",
+      "Justifier 1 Rengi",
+      "Ekrandaki imleç işaretinin rengini değiştirin.",
       {
          { "Blue",             NULL },
          { "Blue (blend)",     NULL },
@@ -400,8 +424,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_justifier2_crosshair",
-      "Justifier 2 Crosshair",
-      "Change the crosshair size on screen.",
+      "Justifier 2 İmleci",
+      "Ekrandaki imleç işaretinin boyutunu değiştirin.",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -426,8 +450,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_justifier2_color",
-      "Justifier 2 Color",
-      "Change the crosshair color on screen.",
+      "Justifier 2 REngi",
+      "Ekrandaki imleç işaretinin rengini değiştirin.",
       {
          { "Pink",             NULL },
          { "Pink (blend)",     NULL },
@@ -465,8 +489,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_rifle_crosshair",
-      "M.A.C.S. Rifle Crosshair",
-      "Change the crosshair size on screen.",
+      "M.A.C.S. Tüfek ",
+      "Ekrandaki imleç işaretinin rengini değiştirin..",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -491,8 +515,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_rifle_color",
-      "M.A.C.S. Rifle Color",
-      "Change the crosshair color on screen.",
+      "M.A.C.S. Tüfek Rengi",
+      "Ekrandaki imleç işaretinin rengini değiştirin.",
       {
          { "White",            NULL },
          { "White (blend)",    NULL },
@@ -530,8 +554,8 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_show_advanced_av_settings",
-      "Show Advanced Audio/Video Settings",
-      "Enable configuration of low-level video layer / GFX effect / audio channel parameters. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      "Gelişmiş Ses/Video Ayarlarını Göster",
+      "Düşük seviye video katmanı / GFX etkisi / ses kanalı parametrelerinin yapılandırılmasını etkinleştirir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün açılması gerekir.",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
@@ -541,7 +565,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_layer_1",
-      "Show Layer 1",
+      "1. Katmanı Göster",
       NULL,
       {
          { "enabled",  NULL },
@@ -552,7 +576,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_layer_2",
-      "Show Layer 2",
+      "2. Katmanı Göster",
       NULL,
       {
          { "enabled",  NULL },
@@ -563,7 +587,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_layer_3",
-      "Show Layer 3",
+      "3. Katmanı Göster",
       NULL,
       {
          { "enabled",  NULL },
@@ -574,7 +598,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_layer_4",
-      "Show Layer 4",
+      "4. Katmanı Göster",
       NULL,
       {
          { "enabled",  NULL },
@@ -585,7 +609,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_layer_5",
-      "Show Sprite Layer",
+      "Sprite Katmanını Göster",
       NULL,
       {
          { "enabled",  NULL },
@@ -596,7 +620,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_gfx_clip",
-      "Enable Graphic Clip Windows",
+      "Grafik Klibi Pencerelerini Etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -607,7 +631,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_gfx_transp",
-      "Enable Transparency Effects",
+      "Saydamlık Efektlerini Etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -618,7 +642,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_1",
-      "Enable Sound Channel 1",
+      "Ses Kanalı 1'i etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -629,7 +653,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_2",
-      "Enable Sound Channel 2",
+      "Ses Kanalı 2'yi etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -640,7 +664,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_3",
-      "Enable Sound Channel 3",
+      "Ses Kanalı 3'ü etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -651,7 +675,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_4",
-      "Enable Sound Channel 4",
+      "Ses Kanalı 4'ü etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -662,7 +686,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_5",
-      "Enable Sound Channel 5",
+      "Ses Kanalı 5'i etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -673,7 +697,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_6",
-      "Enable Sound Channel 6",
+      "Ses Kanalı 6'yı etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -684,7 +708,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_7",
-      "Enable Sound Channel 7",
+      "Ses Kanalı 7'yi etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -695,7 +719,7 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "snes9x_sndchan_8",
-      "Enable Sound Channel 8",
+      "Ses Kanalı 8'i etkinleştir",
       NULL,
       {
          { "enabled",  NULL },
@@ -706,207 +730,6 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
-
-/*
- ********************************
- * Language Mapping
- ********************************
-*/
-
-#ifndef HAVE_NO_LANGEXTRA
-struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
-   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
-   NULL,           /* RETRO_LANGUAGE_JAPANESE */
-   NULL,           /* RETRO_LANGUAGE_FRENCH */
-   NULL,           /* RETRO_LANGUAGE_SPANISH */
-   NULL,           /* RETRO_LANGUAGE_GERMAN */
-   NULL,           /* RETRO_LANGUAGE_ITALIAN */
-   NULL,           /* RETRO_LANGUAGE_DUTCH */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
-   NULL,           /* RETRO_LANGUAGE_KOREAN */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
-   NULL,           /* RETRO_LANGUAGE_POLISH */
-   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
-   NULL,           /* RETRO_LANGUAGE_ARABIC */
-   NULL,           /* RETRO_LANGUAGE_GREEK */
-   option_defs_tr, /* RETRO_LANGUAGE_TURKISH */
-};
-#endif
-
-/*
- ********************************
- * Functions
- ********************************
-*/
-
-/* Handles configuration/setting of core options.
- * Should be called as early as possible - ideally inside
- * retro_set_environment(), and no later than retro_load_game()
- * > We place the function body in the header to avoid the
- *   necessity of adding more .c files (i.e. want this to
- *   be as painless as possible for core devs)
- */
-
-static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
-{
-   unsigned version = 0;
-
-   if (!environ_cb)
-      return;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
-   {
-#ifndef HAVE_NO_LANGEXTRA
-      struct retro_core_options_intl core_options_intl;
-      unsigned language = 0;
-
-      core_options_intl.us    = option_defs_us;
-      core_options_intl.local = NULL;
-
-      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
-          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
-         core_options_intl.local = option_defs_intl[language];
-
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
-#else
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
-#endif
-   }
-   else
-   {
-      size_t i;
-      size_t option_index              = 0;
-      size_t num_options               = 0;
-      struct retro_variable *variables = NULL;
-      char **values_buf                = NULL;
-
-      /* Determine number of options
-       * > Note: We are going to skip a number of irrelevant
-       *   core options when building the retro_variable array,
-       *   but we'll allocate space for all of them. The difference
-       *   in resource usage is negligible, and this allows us to
-       *   keep the code 'cleaner' */
-      while (true)
-      {
-         if (option_defs_us[num_options].key)
-            num_options++;
-         else
-            break;
-      }
-
-      /* Allocate arrays */
-      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
-      values_buf = (char **)calloc(num_options, sizeof(char *));
-
-      if (!variables || !values_buf)
-         goto error;
-
-      /* Copy parameters from option_defs_us array */
-      for (i = 0; i < num_options; i++)
-      {
-         const char *key                        = option_defs_us[i].key;
-         const char *desc                       = option_defs_us[i].desc;
-         const char *default_value              = option_defs_us[i].default_value;
-         struct retro_core_option_value *values = option_defs_us[i].values;
-         size_t buf_len                         = 3;
-         size_t default_index                   = 0;
-
-         values_buf[i] = NULL;
-
-         /* Skip options that are irrelevant when using the
-          * old style core options interface */
-         if ((strcmp(key, "snes9x_show_lightgun_settings") == 0) ||
-             (strcmp(key, "snes9x_show_advanced_av_settings") == 0))
-            continue;
-
-         if (desc)
-         {
-            size_t num_values = 0;
-
-            /* Determine number of values */
-            while (true)
-            {
-               if (values[num_values].value)
-               {
-                  /* Check if this is the default value */
-                  if (default_value)
-                     if (strcmp(values[num_values].value, default_value) == 0)
-                        default_index = num_values;
-
-                  buf_len += strlen(values[num_values].value);
-                  num_values++;
-               }
-               else
-                  break;
-            }
-
-            /* Build values string */
-            if (num_values > 0)
-            {
-               size_t j;
-
-               buf_len += num_values - 1;
-               buf_len += strlen(desc);
-
-               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
-               if (!values_buf[i])
-                  goto error;
-
-               strcpy(values_buf[i], desc);
-               strcat(values_buf[i], "; ");
-
-               /* Default value goes first */
-               strcat(values_buf[i], values[default_index].value);
-
-               /* Add remaining values */
-               for (j = 0; j < num_values; j++)
-               {
-                  if (j != default_index)
-                  {
-                     strcat(values_buf[i], "|");
-                     strcat(values_buf[i], values[j].value);
-                  }
-               }
-            }
-         }
-
-         variables[option_index].key   = key;
-         variables[option_index].value = values_buf[i];
-         option_index++;
-      }
-
-      /* Set variables */
-      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
-
-error:
-
-      /* Clean up */
-      if (values_buf)
-      {
-         for (i = 0; i < num_options; i++)
-         {
-            if (values_buf[i])
-            {
-               free(values_buf[i]);
-               values_buf[i] = NULL;
-            }
-         }
-
-         free(values_buf);
-         values_buf = NULL;
-      }
-
-      if (variables)
-      {
-         free(variables);
-         variables = NULL;
-      }
-   }
-}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
As reported in PR #223, having UTF-8 characters in `libretro_core_options.h` requires a BOM marker + build fix when using MSVC 2010-2013.

Unfortunately, simply adding a BOM breaks any possible compatibility with c89.

This PR fixes the issue by updating the core options definition code to v1.3 format, which means the following:

- All non-US-English translations are moved from `libretro_core_options.h` to a new `libretro_core_options_intl.h` file

- `libretro_core_options_intl.h` includes a BOM marker + the MSVC build fix from PR #223

- We now check for a new define flag: `HAVE_NO_LANGEXTRA`. If this is set, `libretro_core_options_intl.h` is ignored (i.e. we don't break c89 compilation) and only US-English option definitions are used. (Note that `HAVE_NO_LANGEXTRA` is currently unset here for all platforms)

This *replaces* PR #223