### PR TITLE
Add 12-pixel and 16-pixel Crop Overscan options 

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -145,6 +145,8 @@ void retro_set_input_state(retro_input_state_t cb)
 enum overscan_mode {
     OVERSCAN_CROP_ON,
     OVERSCAN_CROP_OFF,
+    OVERSCAN_CROP_12,
+    OVERSCAN_CROP_16,
     OVERSCAN_CROP_AUTO
 };
 enum aspect_mode {
@@ -443,6 +445,10 @@ static void update_variables(void)
         overscan_mode newval = OVERSCAN_CROP_AUTO;
         if (strcmp(var.value, "enabled") == 0)
             newval = OVERSCAN_CROP_ON;
+        else if (strcmp(var.value, "12_pixels") == 0)
+            newval = OVERSCAN_CROP_12;
+        else if (strcmp(var.value, "16_pixels") == 0)
+            newval = OVERSCAN_CROP_16;
         else if (strcmp(var.value, "disabled") == 0)
             newval = OVERSCAN_CROP_OFF;
 
@@ -826,6 +832,10 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     unsigned height = PPU.ScreenHeight;
     if (crop_overscan_mode == OVERSCAN_CROP_ON)
         height = SNES_HEIGHT;
+    else if (crop_overscan_mode == OVERSCAN_CROP_12)
+        height = 216;
+    else if (crop_overscan_mode == OVERSCAN_CROP_16)
+        height = 208;
     else if (crop_overscan_mode == OVERSCAN_CROP_OFF)
         height = SNES_HEIGHT_EXTENDED;
 
@@ -2027,6 +2037,32 @@ bool8 S9xDeinitUpdate(int width, int height)
         {
             overscan_offset = 7;
             height = SNES_HEIGHT;
+        }
+    }
+    else if (crop_overscan_mode == OVERSCAN_CROP_12)
+    {
+        if (height > 216 * 2)
+        {
+            overscan_offset = 8;
+            height = 216 * 2;
+        }
+        else if ((height > 216) && (height != 216 * 2))
+        {
+            overscan_offset = 4;
+            height = 216;
+        }
+    }
+    else if (crop_overscan_mode == OVERSCAN_CROP_16)
+    {
+        if (height > 208 * 2)
+        {
+            overscan_offset = 16;
+            height = 208 * 2;
+        }
+        else if ((height > 208) && (height != 208 * 2))
+        {
+            overscan_offset = 8;
+            height = 208;
         }
     }
     else if (crop_overscan_mode == OVERSCAN_CROP_OFF)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -83,11 +83,13 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "snes9x_overscan",
       "Crop Overscan",
-      "Remove the ~8 pixel borders at the top and bottom of the screen, typically unused by games and hidden by the bezel of a standard-definition television. 'Auto' will attempt to detect and crop overscan based on the current content.",
+      "Remove the borders at the top and bottom of the screen, typically unused by games and hidden by the bezel of a standard-definition television. 'Auto' will attempt to detect and crop the ~8 pixel overscan based on the current content.",
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { "auto",     "Auto" },
+         { "enabled",     "~8 Pixels"},
+         { "12_pixels",   "12 Pixels" },
+         { "16_pixels",   "16 Pixels" },
+         { "auto",        "Auto (~8 Pixels)" },
+         { "disabled",    NULL },
          { NULL, NULL},
       },
       "enabled"

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -107,11 +107,13 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "snes9x_overscan",
       "Aşırı Taramayı Kırp",
-      "Ekranın üst ve alt kısmındaki ~8 piksel sınırlarını, tipik olarak standart çözünürlüklü bir televizyondakini kaldırır. 'Otomatik' ise geçerli içeriğe bağlı olarak aşırı taramayı algılamaya ve kırpmaya çalışacaktır.",
+      "Ekranın üst ve alt kısmındaki sınırlarını, tipik olarak standart çözünürlüklü bir televizyondakini kaldırır. 'Otomatik (~8 piksel)' ise geçerli içeriğe bağlı olarak aşırı taramayı algılamaya ve kırpmaya çalışacaktır.",
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { "auto",     "Otomatik" },
+         { "enabled",      "~8 piksel" },
+         { "12_pixels",    "12 piksel" },
+         { "16_pixels",    "16 piksel" },
+         { "auto",         "Otomatik (~8 piksel)" },
+         { "disabled",     NULL },
          { NULL, NULL},
       },
       "enabled"


### PR DESCRIPTION
This PR introduces a change that takes inspiration from the bsnes-hd and Mesen-S cores.

In its current form, the snes9x libretro implementation allows users to define in the core options whether they want to crop the top and bottom lines of the picture by about 8 pixels, but there are quite a few cases where having a 12-pixel and a 16-pixel crop options might be desirable. Namely:

- As explained by @Derkoun, a 12-pixel crop removes a 5% overscan (exactly 1/5 of 1080p). Moreover, the area of the picture which is eliminated as a result of this crop was still considered as part of the "unsafe" border, so typically for most games no relevant information is shown within that area.

- A 16-pixel crop, as featured in Mesen-S, allows to crop the unused border that was implemented in some games, allowing to have a zoomed fullscreen image without any black bars. One prime example of this is the gameplay sections of Yoshi's Island.

With this PR the core options now allow to select also a 12-pixel or a 16-pixel crop, based on one's preference. The existing configurations / overrides set by users prior to this implementation should not be altered.

A few pictures for comparison's sake:

**_Yoshi's Island - No cropping_**
![Super Mario - Yossy Island (Japan)-210516-195956](https://user-images.githubusercontent.com/17614150/118407901-26089600-b683-11eb-9012-ed89d9547d18.png)

**_Yoshi's Island - Standard crop (about 8 pixels)_**
![Super Mario - Yossy Island (Japan)-210516-195959](https://user-images.githubusercontent.com/17614150/118407931-505a5380-b683-11eb-88e2-da23e6152105.png)

**_Yoshi's Island - 12-pixel crop**
![Super Mario - Yossy Island (Japan)-210516-200001](https://user-images.githubusercontent.com/17614150/118407943-6831d780-b683-11eb-8e1f-5c5e10bcc061.png)

**_Yoshi's Island - 16-pixel crop**
![Super Mario - Yossy Island (Japan)-210516-200003](https://user-images.githubusercontent.com/17614150/118407948-7122a900-b683-11eb-9fc1-dc91d88669fb.png)

---

The modifications applied with this PR are also upstream-friendly, in the sense that the only parts of the code that were altered are libretro-related.

See also this thread by @Awakened0 on the upstream bsnes repo for additional reference:
https://github.com/bsnes-emu/bsnes/issues/169