### PR TITLE
Add core options v2 support

### DIFF
--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2010-2018 The RetroArch team
+/* Copyright (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
  * The following license statement only applies to this libretro API header (libretro.h).
@@ -69,7 +69,7 @@ extern "C" {
 #      endif
 #    endif
 #  else
-#      if defined(__GNUC__) && __GNUC__ >= 4 && !defined(__PS3__)
+#      if defined(__GNUC__) && __GNUC__ >= 4
 #        define RETRO_API RETRO_CALLCONV __attribute__((__visibility__("default")))
 #      else
 #        define RETRO_API RETRO_CALLCONV
@@ -278,6 +278,11 @@ enum retro_language
    RETRO_LANGUAGE_ARABIC              = 16,
    RETRO_LANGUAGE_GREEK               = 17,
    RETRO_LANGUAGE_TURKISH             = 18,
+   RETRO_LANGUAGE_SLOVAK              = 19,
+   RETRO_LANGUAGE_PERSIAN             = 20,
+   RETRO_LANGUAGE_HEBREW              = 21,
+   RETRO_LANGUAGE_ASTURIAN            = 22,
+   RETRO_LANGUAGE_FINNISH             = 23,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -708,6 +713,9 @@ enum retro_mod
                                             * state of rumble motors in controllers.
                                             * A strong and weak motor is supported, and they can be
                                             * controlled indepedently.
+                                            * Should be called from either retro_init() or retro_load_game().
+                                            * Should not be called from retro_set_environment().
+                                            * Returns false if rumble functionality is unavailable.
                                             */
 #define RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES 24
                                            /* uint64_t * --
@@ -1087,10 +1095,10 @@ enum retro_mod
 
 #define RETRO_ENVIRONMENT_GET_TARGET_REFRESH_RATE (50 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                             /* float * --
-                                            * Float value that lets us know what target refresh rate 
+                                            * Float value that lets us know what target refresh rate
                                             * is curently in use by the frontend.
                                             *
-                                            * The core can use the returned value to set an ideal 
+                                            * The core can use the returned value to set an ideal
                                             * refresh rate/framerate.
                                             */
 
@@ -1098,7 +1106,7 @@ enum retro_mod
                                             /* bool * --
                                             * Boolean value that indicates whether or not the frontend supports
                                             * input bitmasks being returned by retro_input_state_t. The advantage
-                                            * of this is that retro_input_state_t has to be only called once to 
+                                            * of this is that retro_input_state_t has to be only called once to
                                             * grab all button states instead of multiple times.
                                             *
                                             * If it returns true, you can pass RETRO_DEVICE_ID_JOYPAD_MASK as 'id'
@@ -1123,6 +1131,13 @@ enum retro_mod
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
                                             * This allows the core to additionally set option sublabel information
                                             * and/or provide localisation support.
+                                            *
+                                            * If version is >= 2, core options may instead be set by passing
+                                            * a retro_core_options_v2 struct to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * or an array of retro_core_options_v2 structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL. This allows the core
+                                            * to additionally set optional core option category information
+                                            * for frontends with core option category support.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
@@ -1164,7 +1179,7 @@ enum retro_mod
                                             * default value is NULL, the first entry in the
                                             * retro_core_option_definition::values array is treated as the default.
                                             *
-                                            * The number of possible options should be very limited,
+                                            * The number of possible option values should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
@@ -1197,6 +1212,7 @@ enum retro_mod
                                             * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
                                             * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
                                             * Afterwards it may be called again for the core to communicate
@@ -1244,6 +1260,456 @@ enum retro_mod
                                             *
                                             * Note that all core option variables will be set visible by
                                             * default when calling SET_VARIABLES/SET_CORE_OPTIONS.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER 56
+                                           /* unsigned * --
+                                            *
+                                            * Allows an implementation to ask frontend preferred hardware
+                                            * context to use. Core should use this information to deal
+                                            * with what specific context to request with SET_HW_RENDER.
+                                            *
+                                            * 'data' points to an unsigned variable
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION 57
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the disk control
+                                            * interface supported by the frontend. If callback return false,
+                                            * API version is assumed to be 0.
+                                            *
+                                            * In legacy code, the disk control interface is defined by passing
+                                            * a struct of type retro_disk_control_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+                                            * This may be still be done regardless of the disk control
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, the disk control interface may
+                                            * instead be defined by passing a struct of type
+                                            * retro_disk_control_ext_callback to
+                                            * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
+                                            * This allows the core to provide additional information about
+                                            * disk images to the frontend and/or enables extra
+                                            * disk control functionality by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE 58
+                                           /* const struct retro_disk_control_ext_callback * --
+                                            * Sets an interface which frontend can use to eject and insert
+                                            * disk images, and also obtain information about individual
+                                            * disk image files registered by the core.
+                                            * This is used for games which consist of multiple images and
+                                            * must be manually swapped out by the user (e.g. PSX, floppy disk
+                                            * based systems).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION 59
+                                           /* unsigned * --
+                                            * Unsigned value is the API version number of the message
+                                            * interface supported by the frontend. If callback returns
+                                            * false, API version is assumed to be 0.
+                                            *
+                                            * In legacy code, messages may be displayed in an
+                                            * implementation-specific manner by passing a struct
+                                            * of type retro_message to RETRO_ENVIRONMENT_SET_MESSAGE.
+                                            * This may be still be done regardless of the message
+                                            * interface version.
+                                            *
+                                            * If version is >= 1 however, messages may instead be
+                                            * displayed by passing a struct of type retro_message_ext
+                                            * to RETRO_ENVIRONMENT_SET_MESSAGE_EXT. This allows the
+                                            * core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MESSAGE_EXT 60
+                                           /* const struct retro_message_ext * --
+                                            * Sets a message to be displayed in an implementation-specific
+                                            * manner for a certain amount of 'frames'. Additionally allows
+                                            * the core to specify message logging level, priority and
+                                            * destination (OSD, logging interface or both).
+                                            * Should not be used for trivial messages, which should simply be
+                                            * logged via RETRO_ENVIRONMENT_GET_LOG_INTERFACE (or as a
+                                            * fallback, stderr).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS 61
+                                           /* unsigned * --
+                                            * Unsigned value is the number of active input devices
+                                            * provided by the frontend. This may change between
+                                            * frames, but will remain constant for the duration
+                                            * of each frame.
+                                            * If callback returns true, a core need not poll any
+                                            * input device with an index greater than or equal to
+                                            * the number of active devices.
+                                            * If callback returns false, the number of active input
+                                            * devices is unknown. In this case, all input devices
+                                            * should be considered active.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
+                                           /* const struct retro_audio_buffer_status_callback * --
+                                            * Lets the core know the occupancy level of the frontend
+                                            * audio buffer. Can be used by a core to attempt frame
+                                            * skipping in order to avoid buffer under-runs.
+                                            * A core may pass NULL to disable buffer status reporting
+                                            * in the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
+                                           /* const unsigned * --
+                                            * Sets minimum frontend audio latency in milliseconds.
+                                            * Resultant audio latency may be larger than set value,
+                                            * or smaller if a hardware limit is encountered. A frontend
+                                            * is expected to honour requests up to 512 ms.
+                                            *
+                                            * - If value is less than current frontend
+                                            *   audio latency, callback has no effect
+                                            * - If value is zero, default frontend audio
+                                            *   latency is set
+                                            *
+                                            * May be used by a core to increase audio latency and
+                                            * therefore decrease the probability of buffer under-runs
+                                            * (crackling) when performing 'intensive' operations.
+                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+                                            * to implement audio-buffer-based frame skipping may achieve
+                                            * optimal results by setting the audio latency to a 'high'
+                                            * (typically 6x or 8x) integer multiple of the expected
+                                            * frame time.
+                                            *
+                                            * WARNING: This can only be called from within retro_run().
+                                            * Calling this can require a full reinitialization of audio
+                                            * drivers in the frontend, so it is important to call it very
+                                            * sparingly, and usually only with the users explicit consent.
+                                            * An eventual driver reinitialize will happen so that audio
+                                            * callbacks happening after this call within the same retro_run()
+                                            * call will target the newly initialized driver.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE 65
+                                           /* const struct retro_system_content_info_override * --
+                                            * Allows an implementation to override 'global' content
+                                            * info parameters reported by retro_get_system_info().
+                                            * Overrides also affect subsystem content info parameters
+                                            * set via RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO.
+                                            * This function must be called inside retro_set_environment().
+                                            * If callback returns false, content info overrides
+                                            * are unsupported by the frontend, and will be ignored.
+                                            * If callback returns true, extended game info may be
+                                            * retrieved by calling RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+                                            * in retro_load_game() or retro_load_game_special().
+                                            *
+                                            * 'data' points to an array of retro_system_content_info_override
+                                            * structs terminated by a { NULL, false, false } element.
+                                            * If 'data' is NULL, no changes will be made to the frontend;
+                                            * a core may therefore pass NULL in order to test whether
+                                            * the RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE and
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT callbacks are supported
+                                            * by the frontend.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_system_content_info_override.
+                                            *
+                                            * Example:
+                                            *
+                                            * - struct retro_system_info:
+                                            * {
+                                            *    "My Core",                      // library_name
+                                            *    "v1.0",                         // library_version
+                                            *    "m3u|md|cue|iso|chd|sms|gg|sg", // valid_extensions
+                                            *    true,                           // need_fullpath
+                                            *    false                           // block_extract
+                                            * }
+                                            *
+                                            * - Array of struct retro_system_content_info_override:
+                                            * {
+                                            *    {
+                                            *       "md|sms|gg", // extensions
+                                            *       false,       // need_fullpath
+                                            *       true         // persistent_data
+                                            *    },
+                                            *    {
+                                            *       "sg",        // extensions
+                                            *       false,       // need_fullpath
+                                            *       false        // persistent_data
+                                            *    },
+                                            *    { NULL, false, false }
+                                            * }
+                                            *
+                                            * Result:
+                                            * - Files of type m3u, cue, iso, chd will not be
+                                            *   loaded by the frontend. Frontend will pass a
+                                            *   valid path to the core, and core will handle
+                                            *   loading internally
+                                            * - Files of type md, sms, gg will be loaded by
+                                            *   the frontend. A valid memory buffer will be
+                                            *   passed to the core. This memory buffer will
+                                            *   remain valid until retro_deinit() returns
+                                            * - Files of type sg will be loaded by the frontend.
+                                            *   A valid memory buffer will be passed to the core.
+                                            *   This memory buffer will remain valid until
+                                            *   retro_load_game() (or retro_load_game_special())
+                                            *   returns
+                                            *
+                                            * NOTE: If an extension is listed multiple times in
+                                            * an array of retro_system_content_info_override
+                                            * structs, only the first instance will be registered
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
+                                           /* const struct retro_game_info_ext ** --
+                                            * Allows an implementation to fetch extended game
+                                            * information, providing additional content path
+                                            * and memory buffer status details.
+                                            * This function may only be called inside
+                                            * retro_load_game() or retro_load_game_special().
+                                            * If callback returns false, extended game information
+                                            * is unsupported by the frontend. In this case, only
+                                            * regular retro_game_info will be available.
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT is guaranteed
+                                            * to return true if RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+                                            * returns true.
+                                            *
+                                            * 'data' points to an array of retro_game_info_ext structs.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_game_info_ext.
+                                            *
+                                            * - If function is called inside retro_load_game(),
+                                            *   the retro_game_info_ext array is guaranteed to
+                                            *   have a size of 1 - i.e. the returned pointer may
+                                            *   be used to access directly the members of the
+                                            *   first retro_game_info_ext struct, for example:
+                                            *
+                                            *      struct retro_game_info_ext *game_info_ext;
+                                            *      if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &game_info_ext))
+                                            *         printf("Content Directory: %s\n", game_info_ext->dir);
+                                            *
+                                            * - If the function is called inside retro_load_game_special(),
+                                            *   the retro_game_info_ext array is guaranteed to have a
+                                            *   size equal to the num_info argument passed to
+                                            *   retro_load_game_special()
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 67
+                                           /* const struct retro_core_options_v2 * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * 'data' points to a retro_core_options_v2 struct, containing
+                                            * of two pointers:
+                                            * - retro_core_options_v2::categories is an array of
+                                            *   retro_core_option_v2_category structs terminated by a
+                                            *   { NULL, NULL, NULL } element. If retro_core_options_v2::categories
+                                            *   is NULL, all core options will have no category and will be shown
+                                            *   at the top level of the frontend core option interface. If frontend
+                                            *   does not have core option category support, categories array will
+                                            *   be ignored.
+                                            * - retro_core_options_v2::definitions is an array of
+                                            *   retro_core_option_v2_definition structs terminated by a
+                                            *   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL }
+                                            *   element.
+                                            *
+                                            * >> retro_core_option_v2_category notes:
+                                            *
+                                            * - retro_core_option_v2_category::key should contain string
+                                            *   that uniquely identifies the core option category. Valid
+                                            *   key characters are [a-z, A-Z, 0-9, _, -]
+                                            *   Namespace collisions with other implementations' category
+                                            *   keys are permitted.
+                                            * - retro_core_option_v2_category::desc should contain a human
+                                            *   readable description of the category key.
+                                            * - retro_core_option_v2_category::info should contain any
+                                            *   additional human readable information text that a typical
+                                            *   user may need to understand the nature of the core option
+                                            *   category.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "advanced_settings",
+                                            *     "Advanced",
+                                            *     "Options affecting low-level emulation performance and accuracy."
+                                            * }
+                                            *
+                                            * >> retro_core_option_v2_definition notes:
+                                            *
+                                            * - retro_core_option_v2_definition::key should be namespaced to not
+                                            *   collide with other implementations' keys. e.g. A core called
+                                            *   'foo' should use keys named as 'foo_option'. Valid key characters
+                                            *   are [a-z, A-Z, 0-9, _, -].
+                                            * - retro_core_option_v2_definition::desc should contain a human readable
+                                            *   description of the key. Will be used when the frontend does not
+                                            *   have core option category support. Examples: "Aspect Ratio" or
+                                            *   "Video > Aspect Ratio".
+                                            * - retro_core_option_v2_definition::desc_categorized should contain a
+                                            *   human readable description of the key, which will be used when
+                                            *   frontend has core option category support. Example: "Aspect Ratio",
+                                            *   where associated retro_core_option_v2_category::desc is "Video".
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::desc will be used instead.
+                                            *   retro_core_option_v2_definition::desc_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::info should contain any additional
+                                            *   human readable information text that a typical user may need to
+                                            *   understand the functionality of the option.
+                                            * - retro_core_option_v2_definition::info_categorized should contain
+                                            *   any additional human readable information text that a typical user
+                                            *   may need to understand the functionality of the option, and will be
+                                            *   used when frontend has core option category support. This is provided
+                                            *   to accommodate the case where info text references an option by
+                                            *   name/desc, and the desc/desc_categorized text for that option differ.
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::info will be used instead.
+                                            *   retro_core_option_v2_definition::info_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::category_key should contain a
+                                            *   category identifier (e.g. "video" or "audio") that will be
+                                            *   assigned to the core option if frontend has core option category
+                                            *   support. A categorized option will be shown in a subsection/
+                                            *   submenu of the frontend core option interface. If key is empty
+                                            *   or NULL, or if key does not match one of the
+                                            *   retro_core_option_v2_category::key values in the associated
+                                            *   retro_core_option_v2_category array, option will have no category
+                                            *   and will be shown at the top level of the frontend core option
+                                            *   interface.
+                                            * - retro_core_option_v2_definition::values is an array of
+                                            *   retro_core_option_value structs terminated by a { NULL, NULL }
+                                            *   element.
+                                            * --> retro_core_option_v2_definition::values[index].value is an
+                                            *     expected option value.
+                                            * --> retro_core_option_v2_definition::values[index].label is a
+                                            *     human readable label used when displaying the value on screen.
+                                            *     If NULL, the value itself is used.
+                                            * - retro_core_option_v2_definition::default_value is the default
+                                            *   core option setting. It must match one of the expected option
+                                            *   values in the retro_core_option_v2_definition::values array. If
+                                            *   it does not, or the default value is NULL, the first entry in the
+                                            *   retro_core_option_v2_definition::values array is treated as the
+                                            *   default.
+                                            *
+                                            * The number of possible option values should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * Example entries:
+                                            *
+                                            * - Uncategorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     NULL,
+                                            *     "Provides increased performance at the expense of reduced accuracy.",
+                                            *     NULL,
+                                            *     NULL,
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * - Categorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Advanced > Speed hack coprocessor X",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Setting 'Advanced > Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "Setting 'Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "advanced_settings",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL 68
+                                           /* const struct retro_core_options_v2_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_v2_intl struct.
+                                            *
+                                            * - retro_core_options_v2_intl::us is a pointer to a
+                                            *   retro_core_options_v2 struct defining the US English
+                                            *   core options implementation. It must point to a valid struct.
+                                            *
+                                            * - retro_core_options_v2_intl::local is a pointer to a
+                                            *   retro_core_options_v2 struct defining core options for
+                                            *   the current frontend language. It may be NULL (in which case
+                                            *   retro_core_options_v2_intl::us is used by the frontend). Any items
+                                            *   missing from this struct will be read from
+                                            *   retro_core_options_v2_intl::us instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_v2_intl::us struct. Any default values in
+                                            * the retro_core_options_v2_intl::local struct will be ignored.
                                             */
 
 /* VFS functionality */
@@ -1922,6 +2388,10 @@ enum retro_sensor_action
 {
    RETRO_SENSOR_ACCELEROMETER_ENABLE = 0,
    RETRO_SENSOR_ACCELEROMETER_DISABLE,
+   RETRO_SENSOR_GYROSCOPE_ENABLE,
+   RETRO_SENSOR_GYROSCOPE_DISABLE,
+   RETRO_SENSOR_ILLUMINANCE_ENABLE,
+   RETRO_SENSOR_ILLUMINANCE_DISABLE,
 
    RETRO_SENSOR_DUMMY = INT_MAX
 };
@@ -1930,6 +2400,10 @@ enum retro_sensor_action
 #define RETRO_SENSOR_ACCELEROMETER_X 0
 #define RETRO_SENSOR_ACCELEROMETER_Y 1
 #define RETRO_SENSOR_ACCELEROMETER_Z 2
+#define RETRO_SENSOR_GYROSCOPE_X 3
+#define RETRO_SENSOR_GYROSCOPE_Y 4
+#define RETRO_SENSOR_GYROSCOPE_Z 5
+#define RETRO_SENSOR_ILLUMINANCE 6
 
 typedef bool (RETRO_CALLCONV *retro_set_sensor_state_t)(unsigned port,
       enum retro_sensor_action action, unsigned rate);
@@ -2127,6 +2601,30 @@ struct retro_frame_time_callback
    retro_usec_t reference;
 };
 
+/* Notifies a libretro core of the current occupancy
+ * level of the frontend audio buffer.
+ *
+ * - active: 'true' if audio buffer is currently
+ *           in use. Will be 'false' if audio is
+ *           disabled in the frontend
+ *
+ * - occupancy: Given as a value in the range [0,100],
+ *              corresponding to the occupancy percentage
+ *              of the audio buffer
+ *
+ * - underrun_likely: 'true' if the frontend expects an
+ *                    audio buffer underrun during the
+ *                    next frame (indicates that a core
+ *                    should attempt frame skipping)
+ *
+ * It will be called right before retro_run() every frame. */
+typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
+      bool active, unsigned occupancy, bool underrun_likely);
+struct retro_audio_buffer_status_callback
+{
+   retro_audio_buffer_status_callback_t callback;
+};
+
 /* Pass this to retro_video_refresh_t if rendering to hardware.
  * Passing NULL to retro_video_refresh_t is still a frame dupe as normal.
  * */
@@ -2287,7 +2785,8 @@ struct retro_keyboard_callback
    retro_keyboard_event_t callback;
 };
 
-/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE.
+/* Callbacks for RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE &
+ * RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE.
  * Should be set for implementations which can swap out multiple disk
  * images in runtime.
  *
@@ -2345,6 +2844,53 @@ typedef bool (RETRO_CALLCONV *retro_replace_image_index_t)(unsigned index,
  * with replace_image_index. */
 typedef bool (RETRO_CALLCONV *retro_add_image_index_t)(void);
 
+/* Sets initial image to insert in drive when calling
+ * core_load_game().
+ * Since we cannot pass the initial index when loading
+ * content (this would require a major API change), this
+ * is set by the frontend *before* calling the core's
+ * retro_load_game()/retro_load_game_special() implementation.
+ * A core should therefore cache the index/path values and handle
+ * them inside retro_load_game()/retro_load_game_special().
+ * - If 'index' is invalid (index >= get_num_images()), the
+ *   core should ignore the set value and instead use 0
+ * - 'path' is used purely for error checking - i.e. when
+ *   content is loaded, the core should verify that the
+ *   disk specified by 'index' has the specified file path.
+ *   This is to guard against auto selecting the wrong image
+ *   if (for example) the user should modify an existing M3U
+ *   playlist. We have to let the core handle this because
+ *   set_initial_image() must be called before loading content,
+ *   i.e. the frontend cannot access image paths in advance
+ *   and thus cannot perform the error check itself.
+ *   If set path and content path do not match, the core should
+ *   ignore the set 'index' value and instead use 0
+ * Returns 'false' if index or 'path' are invalid, or core
+ * does not support this functionality
+ */
+typedef bool (RETRO_CALLCONV *retro_set_initial_image_t)(unsigned index, const char *path);
+
+/* Fetches the path of the specified disk image file.
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or path is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_path_t)(unsigned index, char *path, size_t len);
+
+/* Fetches a core-provided 'label' for the specified disk
+ * image file. In the simplest case this may be a file name
+ * (without extension), but for cores with more complex
+ * content requirements information may be provided to
+ * facilitate user disk swapping - for example, a core
+ * running floppy-disk-based content may uniquely label
+ * save disks, data disks, level disks, etc. with names
+ * corresponding to in-game disk change prompts (so the
+ * frontend can provide better user guidance than a 'dumb'
+ * disk index value).
+ * Returns 'false' if index is invalid (index >= get_num_images())
+ * or label is otherwise unavailable.
+ */
+typedef bool (RETRO_CALLCONV *retro_get_image_label_t)(unsigned index, char *label, size_t len);
+
 struct retro_disk_control_callback
 {
    retro_set_eject_state_t set_eject_state;
@@ -2356,6 +2902,27 @@ struct retro_disk_control_callback
 
    retro_replace_image_index_t replace_image_index;
    retro_add_image_index_t add_image_index;
+};
+
+struct retro_disk_control_ext_callback
+{
+   retro_set_eject_state_t set_eject_state;
+   retro_get_eject_state_t get_eject_state;
+
+   retro_get_image_index_t get_image_index;
+   retro_set_image_index_t set_image_index;
+   retro_get_num_images_t  get_num_images;
+
+   retro_replace_image_index_t replace_image_index;
+   retro_add_image_index_t add_image_index;
+
+   /* NOTE: Frontend will only attempt to record/restore
+    * last used disk index if both set_initial_image()
+    * and get_image_path() are implemented */
+   retro_set_initial_image_t set_initial_image; /* Optional - may be NULL */
+
+   retro_get_image_path_t get_image_path;       /* Optional - may be NULL */
+   retro_get_image_label_t get_image_label;     /* Optional - may be NULL */
 };
 
 enum retro_pixel_format
@@ -2388,6 +2955,104 @@ struct retro_message
    unsigned    frames;     /* Duration in frames of message. */
 };
 
+enum retro_message_target
+{
+   RETRO_MESSAGE_TARGET_ALL = 0,
+   RETRO_MESSAGE_TARGET_OSD,
+   RETRO_MESSAGE_TARGET_LOG
+};
+
+enum retro_message_type
+{
+   RETRO_MESSAGE_TYPE_NOTIFICATION = 0,
+   RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+   RETRO_MESSAGE_TYPE_STATUS,
+   RETRO_MESSAGE_TYPE_PROGRESS
+};
+
+struct retro_message_ext
+{
+   /* Message string to be displayed/logged */
+   const char *msg;
+   /* Duration (in ms) of message when targeting the OSD */
+   unsigned duration;
+   /* Message priority when targeting the OSD
+    * > When multiple concurrent messages are sent to
+    *   the frontend and the frontend does not have the
+    *   capacity to display them all, messages with the
+    *   *highest* priority value should be shown
+    * > There is no upper limit to a message priority
+    *   value (within the bounds of the unsigned data type)
+    * > In the reference frontend (RetroArch), the same
+    *   priority values are used for frontend-generated
+    *   notifications, which are typically assigned values
+    *   between 0 and 3 depending upon importance */
+   unsigned priority;
+   /* Message logging level (info, warn, error, etc.) */
+   enum retro_log_level level;
+   /* Message destination: OSD, logging interface or both */
+   enum retro_message_target target;
+   /* Message 'type' when targeting the OSD
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION: Specifies that a
+    *   message should be handled in identical fashion to
+    *   a standard frontend-generated notification
+    * > RETRO_MESSAGE_TYPE_NOTIFICATION_ALT: Specifies that
+    *   message is a notification that requires user attention
+    *   or action, but that it should be displayed in a manner
+    *   that differs from standard frontend-generated notifications.
+    *   This would typically correspond to messages that should be
+    *   displayed immediately (independently from any internal
+    *   frontend message queue), and/or which should be visually
+    *   distinguishable from frontend-generated notifications.
+    *   For example, a core may wish to inform the user of
+    *   information related to a disk-change event. It is
+    *   expected that the frontend itself may provide a
+    *   notification in this case; if the core sends a
+    *   message of type RETRO_MESSAGE_TYPE_NOTIFICATION, an
+    *   uncomfortable 'double-notification' may occur. A message
+    *   of RETRO_MESSAGE_TYPE_NOTIFICATION_ALT should therefore
+    *   be presented such that visual conflict with regular
+    *   notifications does not occur
+    * > RETRO_MESSAGE_TYPE_STATUS: Indicates that message
+    *   is not a standard notification. This typically
+    *   corresponds to 'status' indicators, such as a core's
+    *   internal FPS, which are intended to be displayed
+    *   either permanently while a core is running, or in
+    *   a manner that does not suggest user attention or action
+    *   is required. 'Status' type messages should therefore be
+    *   displayed in a different on-screen location and in a manner
+    *   easily distinguishable from both standard frontend-generated
+    *   notifications and messages of type RETRO_MESSAGE_TYPE_NOTIFICATION_ALT
+    * > RETRO_MESSAGE_TYPE_PROGRESS: Indicates that message reports
+    *   the progress of an internal core task. For example, in cases
+    *   where a core itself handles the loading of content from a file,
+    *   this may correspond to the percentage of the file that has been
+    *   read. Alternatively, an audio/video playback core may use a
+    *   message of type RETRO_MESSAGE_TYPE_PROGRESS to display the current
+    *   playback position as a percentage of the runtime. 'Progress' type
+    *   messages should therefore be displayed as a literal progress bar,
+    *   where:
+    *   - 'retro_message_ext.msg' is the progress bar title/label
+    *   - 'retro_message_ext.progress' determines the length of
+    *     the progress bar
+    * NOTE: Message type is a *hint*, and may be ignored
+    * by the frontend. If a frontend lacks support for
+    * displaying messages via alternate means than standard
+    * frontend-generated notifications, it will treat *all*
+    * messages as having the type RETRO_MESSAGE_TYPE_NOTIFICATION */
+   enum retro_message_type type;
+   /* Task progress when targeting the OSD and message is
+    * of type RETRO_MESSAGE_TYPE_PROGRESS
+    * > -1:    Unmetered/indeterminate
+    * > 0-100: Current progress percentage
+    * NOTE: Since message type is a hint, a frontend may ignore
+    * progress values. Where relevant, a core should therefore
+    * include progress percentage within the message string,
+    * such that the message intent remains clear when displayed
+    * as a standard frontend-generated notification */
+   int8_t progress;
+};
+
 /* Describes how the libretro implementation maps a libretro input bind
  * to its internal input system through a human readable string.
  * This string can be used to better let a user configure input. */
@@ -2408,7 +3073,7 @@ struct retro_input_descriptor
 struct retro_system_info
 {
    /* All pointers are owned by libretro implementation, and pointers must
-    * remain valid until retro_deinit() is called. */
+    * remain valid until it is unloaded. */
 
    const char *library_name;      /* Descriptive name of library. Should not
                                    * contain any version numbers, etc. */
@@ -2448,6 +3113,213 @@ struct retro_system_info
     * Necessary for certain libretro implementations that load games
     * from zipped archives. */
    bool        block_extract;
+};
+
+/* Defines overrides which modify frontend handling of
+ * specific content file types.
+ * An array of retro_system_content_info_override is
+ * passed to RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_system_content_info_override
+{
+   /* A list of file extensions for which the override
+    * should apply, delimited by a 'pipe' character
+    * (e.g. "md|sms|gg")
+    * Permitted file extensions are limited to those
+    * included in retro_system_info::valid_extensions
+    * and/or retro_subsystem_rom_info::valid_extensions */
+   const char *extensions;
+
+   /* Overrides the need_fullpath value set in
+    * retro_system_info and/or retro_subsystem_rom_info.
+    * To reiterate:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info::path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info::data and retro_game_info::size are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::data and retro_game_info::size are guaranteed
+    *      to be valid
+    *
+    * In addition:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info_ext::full_path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info_ext::archive_path may be NULL
+    *    - retro_game_info_ext::archive_file may be NULL
+    *    - retro_game_info_ext::dir is guaranteed to contain a valid path
+    *      to the directory in which the content file exists
+    *    - retro_game_info_ext::name is guaranteed to contain the
+    *      basename of the content file, without extension
+    *    - retro_game_info_ext::ext is guaranteed to contain the
+    *      extension of the content file in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - If retro_game_info_ext::file_in_archive is false:
+    *       - retro_game_info_ext::full_path is guaranteed to contain
+    *         a valid path to an existent file
+    *       - retro_game_info_ext::archive_path may be NULL
+    *       - retro_game_info_ext::archive_file may be NULL
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the content file exists
+    *       - retro_game_info_ext::name is guaranteed to contain the
+    *         basename of the content file, without extension
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file in lower case format
+    *    - If retro_game_info_ext::file_in_archive is true:
+    *       - retro_game_info_ext::full_path may be NULL
+    *       - retro_game_info_ext::archive_path is guaranteed to
+    *         contain a valid path to an existent compressed file
+    *         inside which the content file is located
+    *       - retro_game_info_ext::archive_file is guaranteed to
+    *         contain a valid path to an existent content file
+    *         inside the compressed file referred to by
+    *         retro_game_info_ext::archive_path
+    *            e.g. for a compressed file '/path/to/foo.zip'
+    *            containing 'bar.sfc'
+    *             > retro_game_info_ext::archive_path will be '/path/to/foo.zip'
+    *             > retro_game_info_ext::archive_file will be 'bar.sfc'
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the compressed file
+    *         (containing the content file) exists
+    *       - retro_game_info_ext::name is guaranteed to contain
+    *         EITHER
+    *         1) the basename of the compressed file (containing
+    *            the content file), without extension
+    *         OR
+    *         2) the basename of the content file inside the
+    *            compressed file, without extension
+    *         In either case, a core should consider 'name' to
+    *         be the canonical name/ID of the the content file
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file inside the compressed file,
+    *         in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size are
+    *      guaranteed to be valid */
+   bool need_fullpath;
+
+   /* If need_fullpath is false, specifies whether the content
+    * data buffer available in retro_load_game() is 'persistent'
+    *
+    * If persistent_data is false and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid only until retro_load_game() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid only until retro_load_game() returns
+    *
+    * If persistent_data is true and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid until retro_deinit() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
+/* Similar to retro_game_info, but provides extended
+ * information about the source content file and
+ * game memory buffer status.
+ * And array of retro_game_info_ext is returned by
+ * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_game_info_ext
+{
+   /* - If file_in_archive is false, contains a valid
+    *   path to an existent content file (UTF-8 encoded)
+    * - If file_in_archive is true, may be NULL */
+   const char *full_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contains a valid path
+    *   to an existent compressed file inside which the
+    *   content file is located (UTF-8 encoded) */
+   const char *archive_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contain a valid path
+    *   to an existent content file inside the compressed
+    *   file referred to by archive_path (UTF-8 encoded)
+    *      e.g. for a compressed file '/path/to/foo.zip'
+    *      containing 'bar.sfc'
+    *      > archive_path will be '/path/to/foo.zip'
+    *      > archive_file will be 'bar.sfc' */
+   const char *archive_file;
+
+   /* - If file_in_archive is false, contains a valid path
+    *   to the directory in which the content file exists
+    *   (UTF-8 encoded)
+    * - If file_in_archive is true, contains a valid path
+    *   to the directory in which the compressed file
+    *   (containing the content file) exists (UTF-8 encoded) */
+   const char *dir;
+
+   /* Contains the canonical name/ID of the content file
+    * (UTF-8 encoded). Intended for use when identifying
+    * 'complementary' content named after the loaded file -
+    * i.e. companion data of a different format (a CD image
+    * required by a ROM), texture packs, internally handled
+    * save files, etc.
+    * - If file_in_archive is false, contains the basename
+    *   of the content file, without extension
+    * - If file_in_archive is true, then string is
+    *   implementation specific. A frontend may choose to
+    *   set a name value of:
+    *   EITHER
+    *   1) the basename of the compressed file (containing
+    *      the content file), without extension
+    *   OR
+    *   2) the basename of the content file inside the
+    *      compressed file, without extension
+    *   RetroArch sets the 'name' value according to (1).
+    *   A frontend that supports routine loading of
+    *   content from archives containing multiple unrelated
+    *   content files may set the 'name' value according
+    *   to (2). */
+   const char *name;
+
+   /* - If file_in_archive is false, contains the extension
+    *   of the content file in lower case format
+    * - If file_in_archive is true, contains the extension
+    *   of the content file inside the compressed file,
+    *   in lower case format */
+   const char *ext;
+
+   /* String of implementation specific meta-data. */
+   const char *meta;
+
+   /* Memory buffer of loaded game content. Will be NULL:
+    * IF
+    * - retro_system_info::need_fullpath is true and
+    *   retro_system_content_info_override::need_fullpath
+    *   is unset
+    * OR
+    * - retro_system_content_info_override::need_fullpath
+    *   is true */
+   const void *data;
+
+   /* Size of game content memory buffer, in bytes */
+   size_t size;
+
+   /* True if loaded content file is inside a compressed
+    * archive */
+   bool file_in_archive;
+
+   /* - If data is NULL, value is unset/ignored
+    * - If data is non-NULL:
+    *   - If persistent_data is false, data and size are
+    *     valid only until retro_load_game() returns
+    *   - If persistent_data is true, data and size are
+    *     are valid until retro_deinit() returns */
+   bool persistent_data;
 };
 
 struct retro_game_geometry
@@ -2561,6 +3433,124 @@ struct retro_core_options_intl
    struct retro_core_option_definition *local;
 };
 
+struct retro_core_option_v2_category
+{
+   /* Variable uniquely identifying the
+    * option category. Valid key characters
+    * are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable category description
+    * > Used as category menu label when
+    *   frontend has core option category
+    *   support */
+   const char *desc;
+
+   /* Human-readable category information
+    * > Used as category menu sublabel when
+    *   frontend has core option category
+    *   support
+    * > Optional (may be NULL or an empty
+    *   string) */
+   const char *info;
+};
+
+struct retro_core_option_v2_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE.
+    * Valid key characters are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend does
+    *   not have core option category support
+    *   e.g. "Video > Aspect Ratio" */
+   const char *desc;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend has
+    *   core option category support
+    *   e.g. "Aspect Ratio", where associated
+    *   retro_core_option_v2_category::desc
+    *   is "Video"
+    * > If empty or NULL, the string specified by
+    *   desc will be used as the menu label
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *desc_categorized;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel */
+   const char *info;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel when frontend
+    *   has core option category support
+    *   (e.g. may be required when info text
+    *   references an option by name/desc,
+    *   and the desc/desc_categorized text
+    *   for that option differ)
+    * > If empty or NULL, the string specified by
+    *   info will be used as the menu sublabel
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *info_categorized;
+
+   /* Variable specifying category (e.g. "video",
+    * "audio") that will be assigned to the option
+    * if frontend has core option category support.
+    * > Categorized options will be displayed in a
+    *   subsection/submenu of the frontend core
+    *   option interface
+    * > Specified string must match one of the
+    *   retro_core_option_v2_category::key values
+    *   in the associated retro_core_option_v2_category
+    *   array; If no match is not found, specified
+    *   string will be considered as NULL
+    * > If specified string is empty or NULL, option will
+    *   have no category and will be shown at the top
+    *   level of the frontend core option interface */
+   const char *category_key;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_v2
+{
+   /* Array of retro_core_option_v2_category structs,
+    * terminated by NULL
+    * > If NULL, all entries in definitions array
+    *   will have no category and will be shown at
+    *   the top level of the frontend core option
+    *   interface
+    * > Will be ignored if frontend does not have
+    *   core option category support */
+   struct retro_core_option_v2_category *categories;
+
+   /* Array of retro_core_option_v2_definition structs,
+    * terminated by NULL */
+   struct retro_core_option_v2_definition *definitions;
+};
+
+struct retro_core_options_v2_intl
+{
+   /* Pointer to a retro_core_options_v2 struct
+    * > US English implementation
+    * > Must point to a valid struct */
+   struct retro_core_options_v2 *us;
+
+   /* Pointer to a retro_core_options_v2 struct
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_options_v2 *local;
+};
+
 struct retro_game_info
 {
    const char *path;       /* Path to game, UTF-8 encoded.
@@ -2605,6 +3595,47 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
 };
 
 /* Callbacks */

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -13,9 +13,10 @@
 
 /*
  ********************************
- * VERSION: 1.3
+ * VERSION: 2.0
  ********************************
  *
+ * - 2.0: Add support for core options v2 interface
  * - 1.3: Move translations to libretro_core_options_intl.h
  *        - libretro_core_options_intl.h includes BOM and utf-8
  *          fix for MSVC 2010-2013
@@ -48,7 +49,26 @@ extern "C" {
  * - Will be used as a fallback for any missing entries in
  *   frontend language definition */
 
-struct retro_core_option_definition option_defs_us[] = {
+struct retro_core_option_v2_category option_cats_us[] = {
+   {
+      "hacks",
+      "Emulation Hacks",
+      "Configure processor overclocking and emulation accuracy parameters affecting low-level performance and compatibility."
+   },
+   {
+      "lightgun",
+      "Light Gun",
+      "Configure Super Scope / Justifier / M.A.C.S. rifle input."
+   },
+   {
+      "advanced_av",
+      "Advanced Audio/Video Settings",
+      "Configure low-level video layer / GFX effect / audio channel parameters."
+   },
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
 
    /* These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
     * Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
@@ -57,70 +77,88 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "snes9x_region",
       "Console Region (Reload Core)",
+      NULL,
       "Specify which region the system is from. 'PAL' is 50hz, 'NTSC' is 60hz. Games will run faster or slower than normal if the incorrect region is selected.",
+      NULL,
+      NULL,
       {
          { "auto", "Auto" },
          { "ntsc", "NTSC" },
          { "pal",  "PAL" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "auto"
    },
    {
       "snes9x_aspect",
       "Preferred Aspect Ratio",
+      NULL,
       "Choose the preferred content aspect ratio. This will only apply when RetroArch's aspect ratio is set to 'Core provided' in the Video settings.",
+      NULL,
+      NULL,
       {
          { "4:3",         NULL },
          { "uncorrected", "Uncorrected" },
          { "auto",        "Auto" },
          { "ntsc",        "NTSC" },
          { "pal",         "PAL" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "4:3"
    },
    {
       "snes9x_overscan",
       "Crop Overscan",
+      NULL,
       "Remove the borders at the top and bottom of the screen, typically unused by games and hidden by the bezel of a standard-definition television. 'Auto' will attempt to detect and crop the ~8 pixel overscan based on the current content.",
+      NULL,
+      NULL,
       {
          { "enabled",     "~8 Pixels"},
          { "12_pixels",   "12 Pixels" },
          { "16_pixels",   "16 Pixels" },
          { "auto",        "Auto (~8 Pixels)" },
          { "disabled",    NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
    {
       "snes9x_gfx_hires",
       "Enable Hi-Res Mode",
+      NULL,
       "Allow games to switch to hi-res mode (512x448) or force all content to output at 256x224 (with crushed pixels).",
+      NULL,
+      NULL,
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
    {
       "snes9x_hires_blend",
       "Hi-Res Blending",
+      NULL,
       "Blend adjacent pixels when game switches to hi-res mode (512x448). Required for certain games that use hi-res mode to produce transparency effects (Kirby's Dream Land, Jurassic Park...).",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "merge",    "Merge" },
          { "blur",     "Blur" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_blargg",
       "Blargg NTSC Filter",
+      NULL,
       "Apply a video filter to mimic various NTSC TV signals.",
+      NULL,
+      NULL,
       {
          { "disabled",   NULL },
          { "monochrome", "Monochrome" },
@@ -128,28 +166,34 @@ struct retro_core_option_definition option_defs_us[] = {
          { "composite",  "Composite" },
          { "s-video",    "S-Video" },
          { "rgb",        "RGB" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_audio_interpolation",
       "Audio Interpolation",
+      NULL,
       "Apply an audio filter. 'Gaussian' reproduces the bass-heavy sound of the original hardware. 'Cubic' and 'Sinc' are less accurate, and preserve more of the high range.",
+      NULL,
+      NULL,
       {
          { "gaussian", "Gaussian" },
          { "cubic",    "Cubic" },
          { "sinc",     "Sinc" },
          { "none",     "None" },
          { "linear",   "Linear" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "gaussian"
    },
    {
       "snes9x_up_down_allowed",
       "Allow Opposing Directions",
+      NULL,
       "Enabling this will allow pressing / quickly alternating / holding both left and right (or up and down) directions at the same time. This may cause movement-based glitches.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -160,7 +204,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "snes9x_overclock_superfx",
       "SuperFX Overclocking",
+      NULL,
       "SuperFX coprocessor frequency multiplier. Can improve frame rate or cause timing errors. Values under 100% can improve game performance on slow devices.",
+      NULL,
+      "hacks",
       {
          { "50%",  NULL },
          { "60%",  NULL },
@@ -176,104 +223,131 @@ struct retro_core_option_definition option_defs_us[] = {
          { "400%", NULL },
          { "450%", NULL },
          { "500%", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "100%"
    },
    {
       "snes9x_overclock_cycles",
       "Reduce Slowdown (Hack, Unsafe)",
+      "Reduce Slowdown (Unsafe)",
       "Overclock SNES CPU. May cause games to crash! Use 'Light' for shorter loading times, 'Compatible' for most games exhibiting slowdown and 'Max' only if absolutely required (Gradius 3, Super R-type...).",
+      NULL,
+      "hacks",
       {
          { "disabled",   NULL },
          { "light",      "Light" },
          { "compatible", "Compatible" },
          { "max",        "Max" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_reduce_sprite_flicker",
       "Reduce Flickering (Hack, Unsafe)",
+      "Reduce Flickering (Unsafe)",
       "Increases number of sprites that can be drawn simultaneously on screen.",
+      NULL,
+      "hacks",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_randomize_memory",
       "Randomize Memory (Unsafe)",
+      NULL,
       "Randomizes system RAM upon start-up. Some games such as 'Super Off Road' use system RAM as a random number generator for item placement and AI behavior, to make gameplay more unpredictable.",
+      NULL,
+      "hacks",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_block_invalid_vram_access",
       "Block Invalid VRAM Access",
+      NULL,
       "Some homebrew/ROM hacks require this option to be disabled for correct operation.",
+      NULL,
+      "hacks",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
    {
       "snes9x_echo_buffer_hack",
       "Echo Buffer Hack (Unsafe, only enable for old addmusic hacks)",
+      NULL,
       "Some homebrew/ROM hacks require this option to be enabled for correct operation.",
+      NULL,
+      "hacks",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_show_lightgun_settings",
       "Show Light Gun Settings",
+      NULL,
       "Enable configuration of Super Scope / Justifier / M.A.C.S. rifle input. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      NULL,
+      NULL,
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_lightgun_mode",
       "Light Gun Mode",
+      "Mode",
       "Use a mouse-controlled 'Light Gun' or 'Touchscreen' input.",
+      NULL,
+      "lightgun",
       {
          { "Lightgun",    "Light Gun" },
          { "Touchscreen", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "Lightgun"
    },
    {
       "snes9x_superscope_reverse_buttons",
       "Super Scope Reverse Trigger Buttons",
+      NULL,
       "Swap the positions of the Super Scope 'Fire' and 'Cursor' buttons.",
+      NULL,
+      "lightgun",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
    {
       "snes9x_superscope_crosshair",
       "Super Scope Crosshair",
+      NULL,
       "Change the crosshair size on screen.",
+      NULL,
+      "lightgun",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -292,14 +366,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "14", NULL },
          { "15", NULL },
          { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "2"
    },
    {
       "snes9x_superscope_color",
       "Super Scope Color",
+      NULL,
       "Change the crosshair color on screen.",
+      NULL,
+      "lightgun",
       {
          { "White",            NULL },
          { "White (blend)",    NULL },
@@ -331,14 +408,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "50% Grey (blend)", NULL },
          { "75% Grey",         NULL },
          { "75% Grey (blend)", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "White"
    },
    {
       "snes9x_justifier1_crosshair",
       "Justifier 1 Crosshair",
+      NULL,
       "Change the crosshair size on screen.",
+      NULL,
+      "lightgun",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -357,14 +437,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "14", NULL },
          { "15", NULL },
          { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "4"
    },
    {
       "snes9x_justifier1_color",
       "Justifier 1 Color",
+      NULL,
       "Change the crosshair color on screen.",
+      NULL,
+      "lightgun",
       {
          { "Blue",             NULL },
          { "Blue (blend)",     NULL },
@@ -396,14 +479,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "Cyan (blend)",     NULL },
          { "Sky",              NULL },
          { "Sky (blend)",      NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "Blue"
    },
    {
       "snes9x_justifier2_crosshair",
       "Justifier 2 Crosshair",
+      NULL,
       "Change the crosshair size on screen.",
+      NULL,
+      "lightgun",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -422,14 +508,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "14", NULL },
          { "15", NULL },
          { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "4"
    },
    {
       "snes9x_justifier2_color",
       "Justifier 2 Color",
+      NULL,
       "Change the crosshair color on screen.",
+      NULL,
+      "lightgun",
       {
          { "Pink",             NULL },
          { "Pink (blend)",     NULL },
@@ -461,14 +550,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "Blue (blend)",     NULL },
          { "Violet",           NULL },
          { "Violet (blend)",   NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "Pink"
    },
    {
       "snes9x_rifle_crosshair",
       "M.A.C.S. Rifle Crosshair",
+      NULL,
       "Change the crosshair size on screen.",
+      NULL,
+      "lightgun",
       {
          { "0",  NULL },
          { "1",  NULL },
@@ -487,14 +579,17 @@ struct retro_core_option_definition option_defs_us[] = {
          { "14", NULL },
          { "15", NULL },
          { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "2"
    },
    {
       "snes9x_rifle_color",
       "M.A.C.S. Rifle Color",
+      NULL,
       "Change the crosshair color on screen.",
+      NULL,
+      "lightgun",
       {
          { "White",            NULL },
          { "White (blend)",    NULL },
@@ -526,18 +621,21 @@ struct retro_core_option_definition option_defs_us[] = {
          { "50% Grey (blend)", NULL },
          { "75% Grey",         NULL },
          { "75% Grey (blend)", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "White"
    },
    {
       "snes9x_show_advanced_av_settings",
       "Show Advanced Audio/Video Settings",
+      NULL,
       "Enable configuration of low-level video layer / GFX effect / audio channel parameters. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      NULL,
+      NULL,
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "disabled"
    },
@@ -545,10 +643,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_layer_1",
       "Show Layer 1",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -556,10 +657,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_layer_2",
       "Show Layer 2",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -567,10 +671,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_layer_3",
       "Show Layer 3",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -578,10 +685,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_layer_4",
       "Show Layer 4",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -589,10 +699,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_layer_5",
       "Show Sprite Layer",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -600,10 +713,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_gfx_clip",
       "Enable Graphic Clip Windows",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -611,10 +727,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_gfx_transp",
       "Enable Transparency Effects",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -622,10 +741,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_1",
       "Enable Sound Channel 1",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -633,10 +755,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_2",
       "Enable Sound Channel 2",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -644,10 +769,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_3",
       "Enable Sound Channel 3",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -655,10 +783,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_4",
       "Enable Sound Channel 4",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -666,10 +797,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_5",
       "Enable Sound Channel 5",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -677,10 +811,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_6",
       "Enable Sound Channel 6",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -688,10 +825,13 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_7",
       "Enable Sound Channel 7",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
@@ -699,14 +839,22 @@ struct retro_core_option_definition option_defs_us[] = {
       "snes9x_sndchan_8",
       "Enable Sound Channel 8",
       NULL,
+      NULL,
+      NULL,
+      "advanced_av",
       {
          { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "enabled"
    },
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
 };
 
 /*
@@ -716,26 +864,31 @@ struct retro_core_option_definition option_defs_us[] = {
 */
 
 #ifndef HAVE_NO_LANGEXTRA
-struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
-   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
-   NULL,           /* RETRO_LANGUAGE_JAPANESE */
-   NULL,           /* RETRO_LANGUAGE_FRENCH */
-   NULL,           /* RETRO_LANGUAGE_SPANISH */
-   NULL,           /* RETRO_LANGUAGE_GERMAN */
-   NULL,           /* RETRO_LANGUAGE_ITALIAN */
-   NULL,           /* RETRO_LANGUAGE_DUTCH */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
-   NULL,           /* RETRO_LANGUAGE_KOREAN */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
-   NULL,           /* RETRO_LANGUAGE_POLISH */
-   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
-   NULL,           /* RETRO_LANGUAGE_ARABIC */
-   NULL,           /* RETRO_LANGUAGE_GREEK */
-   option_defs_tr, /* RETRO_LANGUAGE_TURKISH */
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,        /* RETRO_LANGUAGE_JAPANESE */
+   NULL,        /* RETRO_LANGUAGE_FRENCH */
+   NULL,        /* RETRO_LANGUAGE_SPANISH */
+   NULL,        /* RETRO_LANGUAGE_GERMAN */
+   NULL,        /* RETRO_LANGUAGE_ITALIAN */
+   NULL,        /* RETRO_LANGUAGE_DUTCH */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,        /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,        /* RETRO_LANGUAGE_KOREAN */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,        /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,        /* RETRO_LANGUAGE_POLISH */
+   NULL,        /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,        /* RETRO_LANGUAGE_ARABIC */
+   NULL,        /* RETRO_LANGUAGE_GREEK */
+   &options_tr, /* RETRO_LANGUAGE_TURKISH */
+   NULL,        /* RETRO_LANGUAGE_SLOVAK */
+   NULL,        /* RETRO_LANGUAGE_PERSIAN */
+   NULL,        /* RETRO_LANGUAGE_HEBREW */
+   NULL,        /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,        /* RETRO_LANGUAGE_FINNISH */
 };
 #endif
 
@@ -753,45 +906,61 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
  *   be as painless as possible for core devs)
  */
 
-static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
 {
-   unsigned version = 0;
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
 
-   if (!environ_cb)
+   if (!environ_cb || !categories_supported)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
+   *categories_supported = false;
+
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
    {
 #ifndef HAVE_NO_LANGEXTRA
-      struct retro_core_options_intl core_options_intl;
-      unsigned language = 0;
+      struct retro_core_options_v2_intl core_options_intl;
 
-      core_options_intl.us    = option_defs_us;
+      core_options_intl.us    = &options_us;
       core_options_intl.local = NULL;
 
       if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
           (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
-         core_options_intl.local = option_defs_intl[language];
+         core_options_intl.local = options_intl[language];
 
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
 #else
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
 #endif
    }
    else
    {
-      size_t i;
+      size_t i, j;
       size_t option_index              = 0;
       size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
       struct retro_variable *variables = NULL;
       char **values_buf                = NULL;
 
-      /* Determine number of options
-       * > Note: We are going to skip a number of irrelevant
-       *   core options when building the retro_variable array,
-       *   but we'll allocate space for all of them. The difference
-       *   in resource usage is negligible, and this allows us to
-       *   keep the code 'cleaner' */
+      /* Determine total number of options */
       while (true)
       {
          if (option_defs_us[num_options].key)
@@ -800,93 +969,193 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             break;
       }
 
-      /* Allocate arrays */
-      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
-      values_buf = (char **)calloc(num_options, sizeof(char *));
-
-      if (!variables || !values_buf)
-         goto error;
-
-      /* Copy parameters from option_defs_us array */
-      for (i = 0; i < num_options; i++)
+      if (version >= 1)
       {
-         const char *key                        = option_defs_us[i].key;
-         const char *desc                       = option_defs_us[i].desc;
-         const char *default_value              = option_defs_us[i].default_value;
-         struct retro_core_option_value *values = option_defs_us[i].values;
-         size_t buf_len                         = 3;
-         size_t default_index                   = 0;
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
 
-         values_buf[i] = NULL;
-
-         /* Skip options that are irrelevant when using the
-          * old style core options interface */
-         if ((strcmp(key, "snes9x_show_lightgun_settings") == 0) ||
-             (strcmp(key, "snes9x_show_advanced_av_settings") == 0))
-            continue;
-
-         if (desc)
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
          {
-            size_t num_values = 0;
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
 
-            /* Determine number of values */
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
             while (true)
             {
-               if (values[num_values].value)
-               {
-                  /* Check if this is the default value */
-                  if (default_value)
-                     if (strcmp(values[num_values].value, default_value) == 0)
-                        default_index = num_values;
-
-                  buf_len += strlen(values[num_values].value);
-                  num_values++;
-               }
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
                else
                   break;
             }
 
-            /* Build values string */
-            if (num_values > 0)
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
             {
-               size_t j;
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
 
-               buf_len += num_values - 1;
-               buf_len += strlen(desc);
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
 
-               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
-               if (!values_buf[i])
-                  goto error;
-
-               strcpy(values_buf[i], desc);
-               strcat(values_buf[i], "; ");
-
-               /* Default value goes first */
-               strcat(values_buf[i], values[default_index].value);
-
-               /* Add remaining values */
-               for (j = 0; j < num_values; j++)
+               /* Values must be copied individually... */
+               while (option_values->value)
                {
-                  if (j != default_index)
-                  {
-                     strcat(values_buf[i], "|");
-                     strcat(values_buf[i], values[j].value);
-                  }
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
                }
             }
          }
 
-         variables[option_index].key   = key;
-         variables[option_index].value = values_buf[i];
-         option_index++;
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
+      }
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            /* Skip options that are irrelevant when using the
+             * old style core options interface */
+            if ((strcmp(key, "snes9x_show_lightgun_settings") == 0) ||
+                (strcmp(key, "snes9x_show_advanced_av_settings") == 0))
+               continue;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
       }
 
-      /* Set variables */
-      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
-
 error:
-
       /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
       if (values_buf)
       {
          for (i = 0; i < num_options; i++)

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -11,9 +11,10 @@
 
 /*
  ********************************
- * VERSION: 1.3
+ * VERSION: 2.0
  ********************************
  *
+ * - 2.0: Add support for core options v2 interface
  * - 1.3: Move translations to libretro_core_options_intl.h
  *        - libretro_core_options_intl.h includes BOM and utf-8
  *          fix for MSVC 2010-2013
@@ -73,665 +74,562 @@ extern "C" {
 
 /* RETRO_LANGUAGE_TURKISH */
 
-struct retro_core_option_definition option_defs_tr[] = {
+struct retro_core_option_v2_category option_cats_tr[] = {
+   {
+      "hacks",
+      NULL,
+      NULL
+   },
+   {
+      "lightgun",
+      NULL,
+      NULL
+   },
+   {
+      "advanced_av",
+      NULL,
+      NULL
+   },
+   { NULL, NULL, NULL },
+};
 
-   /* These variable names and possible values constitute an ABI with ZMZ (ZSNES Libretro player).
-    * Changing "Show layer 1" is fine, but don't change "layer_1"/etc or the possible values ("Yes|No").
-    * Adding more variables and rearranging them is safe. */
-      {
+struct retro_core_option_v2_definition option_defs_tr[] = {
+   {
       "snes9x_region",
       "Konsol Bölgesi (Core Yenilenir)",
+      NULL,
       "Sistemin hangi bölgeden olduğunu belirtir.. 'PAL' 50hz'dir, 'NTSC' ise 60hz. Yanlış bölge seçiliyse, oyunlar normalden daha hızlı veya daha yavaş çalışacaktır.",
+      NULL,
+      NULL,
       {
          { "auto", "Otomatik" },
          { "ntsc", "NTSC" },
          { "pal",  "PAL" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "auto"
+      NULL
    },
    {
       "snes9x_aspect",
       "Tercih Edilen En Boy Oranı",
+      NULL,
       "Tercih edilen içerik en boy oranını seçin. Bu, yalnızca RetroArch’ın en boy oranı Video ayarlarında 'Core tarafından' olarak ayarlandığında uygulanacaktır.",
+      NULL,
+      NULL,
       {
          { "4:3",         NULL },
          { "uncorrected", "Düzeltilmemiş" },
          { "auto",        "Otomatik" },
          { "ntsc",        "NTSC" },
          { "pal",         "PAL" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "4:3"
+      NULL
    },
    {
       "snes9x_overscan",
       "Aşırı Taramayı Kırp",
+      NULL,
       "Ekranın üst ve alt kısmındaki sınırlarını, tipik olarak standart çözünürlüklü bir televizyondakini kaldırır. 'Otomatik (~8 piksel)' ise geçerli içeriğe bağlı olarak aşırı taramayı algılamaya ve kırpmaya çalışacaktır.",
+      NULL,
+      NULL,
       {
          { "enabled",      "~8 piksel" },
          { "12_pixels",    "12 piksel" },
          { "16_pixels",    "16 piksel" },
          { "auto",         "Otomatik (~8 piksel)" },
          { "disabled",     NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_gfx_hires",
       "Hi-Res Modunu Etkinleştir",
+      NULL,
       "Oyunların hi-res moduna (512x448) geçmesine izin verir veya tüm içeriği 256x224'te (ezilmiş piksellerle) çıkmaya zorlar.",
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_hires_blend",
       "Hi-Res Karışımı",
+      NULL,
       "Oyun hi-res moduna geçtiğinde pikselleri karıştırır (512x448). Şeffaflık efektleri üretmek için hi-res modunu kullanan bazı oyunlar için gereklidir (Kirby's Dream Land, Jurassic Park ...).",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "merge",    "Birlşetir" },
          { "blur",     "Bulanıklaştır" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_blargg",
       "Blargg NTSC Filtresi",
+      NULL,
       "Çeşitli NTSC TV sinyallerini taklit etmek için bir video filtresi uygular.",
+      NULL,
+      NULL,
       {
-         { "disabled",   NULL },
-         { "monochrome", "Monochrome" },
-         { "rf",         "RF" },
-         { "composite",  "Composite" },
-         { "s-video",    "S-Video" },
-         { "rgb",        "RGB" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_audio_interpolation",
       "Ses Enterpolasyonu",
+      NULL,
       "Belirtilen ses filtresini uygular. 'Gaussian', orijinal donanımın bas ağırlıklı sesini üretir. 'Cubic' ve 'Sinc' daha az doğrudur ve daha fazla aralığı korur.",
+      NULL,
+      NULL,
       {
          { "gaussian", "Gaussian" },
          { "cubic",    "Cubic" },
          { "sinc",     "Sinc" },
          { "none",     "Hiçbiri" },
          { "linear",   "Linear" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "gaussian"
+      NULL
    },
    {
       "snes9x_up_down_allowed",
       "Karşı Yönlere İzin Ver",
+      NULL,
       "Bunu etkinleştirmek aynı anda hem sola hem de sağa (veya yukarı ve aşağı) yönlere basma / hızlı değiştirme / tutma imkanı sağlar. Bu harekete dayalı hatalara neden olabilir.",
+      NULL,
+      NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
          { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_overclock_superfx",
       "SuperFX Hız Aşırtma",
+      NULL,
       "SuperFX işlemcisi frekans çarpanıdır. Kare hızını artırabilir veya zamanlama hatalarına neden olabilir. % 100'ün altındaki değerler yavaş cihazlarda oyun performansını artırabilir.",
+      NULL,
+      NULL,
       {
-         { "50%",  NULL },
-         { "60%",  NULL },
-         { "70%",  NULL },
-         { "80%",  NULL },
-         { "90%",  NULL },
-         { "100%", NULL },
-         { "150%", NULL },
-         { "200%", NULL },
-         { "250%", NULL },
-         { "300%", NULL },
-         { "350%", NULL },
-         { "400%", NULL },
-         { "450%", NULL },
-         { "500%", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "100%"
+      NULL
    },
    {
       "snes9x_overclock_cycles",
       "Yavaşlamayı Azalt (Hack, Güvensiz)",
+      "Yavaşlamayı Azalt (Güvensiz)",
       "SNES İşlemcisi için hız aşırtmadır. Oyunların çökmesine neden olabilir! Daha kısa yükleme süreleri için 'Hafif'i, yavaşlama gösteren oyunların çoğunda' Uyumlu 've yalnızca kesinlikle gerekliyse' Maks 'kullanın (Gradius 3, Süper R tipi ...).",
+      NULL,
+      NULL,
       {
          { "disabled",   NULL },
          { "light",      "Hafif" },
          { "compatible", "Uyumlu" },
          { "max",        "Maks" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_reduce_sprite_flicker",
       "Kırılmayı Azalt (Hack, Güvensiz)",
+      "Kırılmayı Azalt (Güvensiz)",
       "Ekranda aynı anda çizilebilen sprite sayısını arttırır.",
+      NULL,
+      NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_randomize_memory",
       "Belleği Rastgele Kıl (Güvensiz)",
+      NULL,
       "Başlatıldığında sistem RAM'ını rastgele ayarlar. 'Super Off Road' gibi bazı oyunlar, oyunu daha öngörülemeyen hale getirmek için öğe yerleştirme ve AI davranışı için rastgele sayı üreticisi olarak sistem RAM'ini kullanır.",
+      NULL,
+      NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_block_invalid_vram_access",
       "Geçersiz VRAM Erişimini Engelle",
+      NULL,
       "Bazı Homebrew/ROM'lar, doğru işlem için bu seçeneğin devre dışı bırakılmasını gerektirir.",
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_echo_buffer_hack",
       "Eko Tampon Hack (Güvenli değil, yalnızca eski addmusic için etkinleştirin)",
+      NULL,
       "Bazı Homebrew/ROM'lar, doğru işlem için bu seçeneğin devre dışı bırakılmasını gerektirir.",
+      NULL,
+      NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_show_lightgun_settings",
       "Light Gun Ayarlarını Göster",
+      NULL,
       "Super Scope / Justifier / M.A.C.S. için tüfek girişi yapılandırmasını etkinleştir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün açılması gerekir.",
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_lightgun_mode",
       "Light Gun Modu",
+      "Modu",
       "Fare kontrollü 'Light Gun' veya 'Dokunmatik Ekran' girişini kullanın.",
+      NULL,
+      NULL,
       {
          { "Lightgun",    "Light Gun" },
          { "Touchscreen", "Dokunmatik Ekran" },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "Lightgun"
+      NULL
    },
    {
       "snes9x_superscope_reverse_buttons",
       "Super Scope Ters Tetik Düğmeleri",
+      NULL,
       "Süper Scope için 'Ateş' ve 'İmleç' butonlarının pozisyonlarını değiştir.",
+      NULL,
+      NULL,
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_superscope_crosshair",
       "Super Scope İmkeç",
+      NULL,
       "Ekrandaki imleç işaretini değiştirin.",
+      NULL,
+      NULL,
       {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "2"
+      NULL
    },
    {
       "snes9x_superscope_color",
       "Super Scope Rengi",
+      NULL,
       "Ekrandaki imleç işaretinin rengini değiştirin.",
+      NULL,
+      NULL,
       {
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "White"
+      NULL
    },
    {
       "snes9x_justifier1_crosshair",
       "Justifier 1 İmleci",
+      NULL,
       "Ekrandaki imleç işaretinin boyutunu değiştirin.",
+      NULL,
+      NULL,
       {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "4"
+      NULL
    },
    {
       "snes9x_justifier1_color",
       "Justifier 1 Rengi",
+      NULL,
       "Ekrandaki imleç işaretinin rengini değiştirin.",
+      NULL,
+      NULL,
       {
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "Blue"
+      NULL
    },
    {
       "snes9x_justifier2_crosshair",
       "Justifier 2 İmleci",
+      NULL,
       "Ekrandaki imleç işaretinin boyutunu değiştirin.",
+      NULL,
+      NULL,
       {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "4"
+      NULL
    },
    {
       "snes9x_justifier2_color",
       "Justifier 2 REngi",
+      NULL,
       "Ekrandaki imleç işaretinin rengini değiştirin.",
+      NULL,
+      NULL,
       {
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "Pink"
+      NULL
    },
    {
       "snes9x_rifle_crosshair",
       "M.A.C.S. Tüfek ",
+      NULL,
       "Ekrandaki imleç işaretinin rengini değiştirin..",
+      NULL,
+      NULL,
       {
-         { "0",  NULL },
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "2"
+      NULL
    },
    {
       "snes9x_rifle_color",
       "M.A.C.S. Tüfek Rengi",
+      NULL,
       "Ekrandaki imleç işaretinin rengini değiştirin.",
+      NULL,
+      NULL,
       {
-         { "White",            NULL },
-         { "White (blend)",    NULL },
-         { "Red",              NULL },
-         { "Red (blend)",      NULL },
-         { "Orange",           NULL },
-         { "Orange (blend)",   NULL },
-         { "Yellow",           NULL },
-         { "Yellow (blend)",   NULL },
-         { "Green",            NULL },
-         { "Green (blend)",    NULL },
-         { "Cyan",             NULL },
-         { "Cyan (blend)",     NULL },
-         { "Sky",              NULL },
-         { "Sky (blend)",      NULL },
-         { "Blue",             NULL },
-         { "Blue (blend)",     NULL },
-         { "Violet",           NULL },
-         { "Violet (blend)",   NULL },
-         { "Pink",             NULL },
-         { "Pink (blend)",     NULL },
-         { "Purple",           NULL },
-         { "Purple (blend)",   NULL },
-         { "Black",            NULL },
-         { "Black (blend)",    NULL },
-         { "25% Grey",         NULL },
-         { "25% Grey (blend)", NULL },
-         { "50% Grey",         NULL },
-         { "50% Grey (blend)", NULL },
-         { "75% Grey",         NULL },
-         { "75% Grey (blend)", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "White"
+      NULL
    },
    {
       "snes9x_show_advanced_av_settings",
       "Gelişmiş Ses/Video Ayarlarını Göster",
+      NULL,
       "Düşük seviye video katmanı / GFX etkisi / ses kanalı parametrelerinin yapılandırılmasını etkinleştirir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün açılması gerekir.",
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "disabled"
+      NULL
    },
    {
       "snes9x_layer_1",
       "1. Katmanı Göster",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_layer_2",
       "2. Katmanı Göster",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_layer_3",
       "3. Katmanı Göster",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+        { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_layer_4",
       "4. Katmanı Göster",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_layer_5",
       "Sprite Katmanını Göster",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_gfx_clip",
       "Grafik Klibi Pencerelerini Etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_gfx_transp",
       "Saydamlık Efektlerini Etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_1",
       "Ses Kanalı 1'i etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_2",
       "Ses Kanalı 2'yi etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_3",
       "Ses Kanalı 3'ü etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_4",
       "Ses Kanalı 4'ü etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_5",
       "Ses Kanalı 5'i etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_6",
       "Ses Kanalı 6'yı etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_7",
       "Ses Kanalı 7'yi etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
    {
       "snes9x_sndchan_8",
       "Ses Kanalı 8'i etkinleştir",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
-         { "enabled",  NULL },
-         { "disabled", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
-      "enabled"
+      NULL
    },
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
 };
+
+struct retro_core_options_v2 options_tr = {
+   option_cats_tr,
+   option_defs_tr
+};
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds core option v2 support. On frontends with core option category support, a number of lesser-used options have been moved to appropriate submenus:

![Screenshot_2021-08-10_12-10-15](https://user-images.githubusercontent.com/38211560/128859325-142eef85-0053-4b88-aefc-c2cb20b9bb78.png)

![Screenshot_2021-08-10_12-10-38](https://user-images.githubusercontent.com/38211560/128859339-53399dc9-ed40-41b5-9087-ae4ef993d824.png)

![Screenshot_2021-08-10_12-10-57](https://user-images.githubusercontent.com/38211560/128859358-3aa0c5b9-a642-491c-9147-301ef8d172b1.png)

![Screenshot_2021-08-10_12-11-12](https://user-images.githubusercontent.com/38211560/128859372-cfec5318-5600-4ca4-a2ab-0a6083aefe15.png)
