### PR TITLE
Restore Haiku build

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -64,9 +64,6 @@ ifneq (,$(findstring unix,$(platform)))
    LIBS += -lz
    SHARED := -shared -Wl,--version-script=link.T -Wl,-z,defs
    endif
-   ifneq ($(findstring Haiku,$(shell uname -a)),)
-      LIBS :=
-   endif
 
    # ARM
    ifneq (,$(findstring armv,$(platform)))


### PR DESCRIPTION
I don't remember specifically why this was added to the original Makefile, but there probably was a good reason at the time.
Nowadays, it breaks the Haiku build because the linker cannot find the zlib, which makes sense, so I am really unsure why this was added in the first place. Oh well.