### PR TITLE
Fix visibility of 'hidable' core options when option categories are supported

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -202,10 +202,16 @@ void retro_set_environment(retro_environment_t cb)
 
     cb(RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO,  (void*)subsystems);
 
-
-    libretro_supports_option_categories = false;
-    libretro_set_core_options(environ_cb,
-            &libretro_supports_option_categories);
+    /* An annoyance: retro_set_environment() can be called
+     * multiple times, and depending upon the current frontend
+     * state various environment callbacks may be disabled.
+     * This means the reported 'categories_supported' status
+     * may change on subsequent iterations. We therefore have
+     * to record whether 'categories_supported' is true on any
+     * iteration, and latch the result */
+    bool option_categories = false;
+    libretro_set_core_options(environ_cb, &option_categories);
+    libretro_supports_option_categories |= option_categories;
 
     /* If frontend supports core option categories,
      * show/hide toggle options are unused and should


### PR DESCRIPTION
This trivial PR fixes a bug that causes 'visibility toggle' options to be mishandled when the frontend supports core option categories.

Closes #270