### PR TITLE
(WiiU) Fix for modern devkitPPC versions

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -338,13 +338,12 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    CXXFLAGS += -mcpu=750 -meabi -mhard-float -DBLARGG_BIG_ENDIAN=1 -D__ppc__
-   CXXFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
    STATIC_LINKING=1
    STATIC_LINKING_LINK=1
    
    # Nintendo WiiU	
    ifneq (,$(findstring wiiu,$(platform)))	
-      CXXFLAGS += -mwup
+      CXXFLAGS += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
 
    # Nintendo Wii
    else ifneq (,$(findstring wii,$(platform)))


### PR DESCRIPTION
This change removes the old -mwup flag that is no longer in current versions of devkitPPC. The equivalent flags are provided instead.

This change also removes the int/long int tweaks use for the version of devkitPPC that RetroArch is currently pinned to. This will cause new, non-fatal, meaningless compiler warnings on this old version. The build and core still work fine. These warnings will be silenced when the project updates to a newer version of devkitPPC.

This is the same type of change we could expect all cores to need as per https://github.com/libretro/RetroArch/issues/14429.